### PR TITLE
Allow Disable of Grafana Dashboards / External Target Configuration

### DIFF
--- a/charts/policy-reporter/Chart.lock
+++ b/charts/policy-reporter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: monitoring
   repository: ""
-  version: 1.4.4
+  version: 1.5.0
 - name: ui
   repository: ""
   version: 1.10.0
 - name: kyvernoPlugin
   repository: ""
   version: 0.7.0
-digest: sha256:93996a41bb416445ba7e5c8fe29650a811671b9970bd0366aa09c860cfedc91c
-generated: "2021-09-27T09:56:18.1815481+02:00"
+digest: sha256:9c81be2f483771e0192cc4309d58ee754502f51df7f1cd55bc50d207370dbc98
+generated: "2021-10-13T14:25:35.257173006+02:00"

--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,14 +5,14 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 1.11.0
+version: 1.12.0
 appVersion: 1.9.0
 
 dependencies:
   - name: monitoring
     condition: monitoring.enabled
     repository: ""
-    version: "1.4.4"
+    version: "1.5.0"
   - name: ui
     condition: ui.enabled
     repository: ""

--- a/charts/policy-reporter/charts/monitoring/Chart.yaml
+++ b/charts/policy-reporter/charts/monitoring/Chart.yaml
@@ -3,5 +3,5 @@ name: monitoring
 description: Policy Reporter Monitoring with predefined ServiceMonitor and Grafana Dashboards
 
 type: application
-version: 1.4.4
+version: 1.5.0
 appVersion: 0.0.0

--- a/charts/policy-reporter/charts/monitoring/templates/clusterpolicy-details.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/clusterpolicy-details.dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.grafana.dashboards.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -810,3 +811,4 @@ data:
     "uid": "iyJszGUMk",
     "version": 1
     }
+{{- end }}

--- a/charts/policy-reporter/charts/monitoring/templates/overview.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/overview.dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.grafana.dashboards.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -478,3 +479,4 @@ data:
     "title": "PolicyReports",
     "version": 1
     }
+{{- end }}

--- a/charts/policy-reporter/charts/monitoring/templates/policy-details.dashboard.yaml
+++ b/charts/policy-reporter/charts/monitoring/templates/policy-details.dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.grafana.dashboards.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -830,3 +831,4 @@ data:
     "uid": "Tf1skG8Mz",
     "version": 1
     }
+{{- end }}

--- a/charts/policy-reporter/charts/monitoring/values.yaml
+++ b/charts/policy-reporter/charts/monitoring/values.yaml
@@ -14,6 +14,8 @@ grafana:
   # namespace for configMap of grafana dashboards
   namespace:
   dashboards:
+    # Enable the deployment of grafana dashboards
+    enabled: true 
     # Label to find dashboards using the k8s sidecar
     label: grafana_dashboard
   folder:

--- a/charts/policy-reporter/templates/deployment.yaml
+++ b/charts/policy-reporter/templates/deployment.yaml
@@ -66,15 +66,23 @@ spec:
           volumeMounts:
           - name: config-file
             mountPath: /app/config.yaml
+            {{- if and .Values.existingTargetConfig.enabled .Values.existingTargetConfig.subPath }}
+            subPath: {{ .Values.existingTargetConfig.subPath }}
+            {{- else }}
             subPath: config.yaml
+            {{- end }}
           env:
           - name: NAMESPACE
             value: {{ .Release.Namespace }}
       volumes:
       - name: config-file
         secret:
+          {{- if and .Values.existingTargetConfig.enabled .Values.existingTargetConfig.name }}
+          secretName: {{ .Values.existingTargetConfig.name }}
+          {{- else }}
           secretName: {{ include "policyreporter.fullname" . }}-targets
-          optional: true
+          {{- end }}
+          optional: true   
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/policy-reporter/templates/targetssecret.yaml
+++ b/charts/policy-reporter/templates/targetssecret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingTargetConfig.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   config.yaml: {{ tpl (.Files.Get "config.yaml") . | b64enc }}
+{{- end }}  

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -128,6 +128,14 @@ policyPriorities:
   #   require-ns-labels: error
   mapping: {}
 
+# Reference a configuration which already exists instead of creating one
+existingTargetConfig: 
+  enabled: false
+  # Name of the secret with the config
+  name: ""
+  # subPath within the secret (defaults to config.yaml)
+  subPath: ""
+
 # Supported targets for new PolicyReport Results
 target:
   loki:

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -129,7 +129,7 @@ policyPriorities:
   mapping: {}
 
 # Reference a configuration which already exists instead of creating one
-existingTargetConfig: 
+existingTargetConfig:
   enabled: false
   # Name of the secret with the config
   name: ""


### PR DESCRIPTION
Signed-off-by: Oliver Bähler <oliverbaehler@hotmail.com>

This PR adds two new features.

**Chart [monitoring]**: 

* Adds `.Values.grafana.dashboards.enabled` value which is set to `true`by default. This allows users to disable the deployment of grafana dashboards.

Bumped to version `1.5.0` 

**Chart [policy-reporter]**: 

* Updated Dependency for monitoring chart to 1.5.0
* Add new configuration key which allows the reference of an existing target configuration under `.Values.existingTargetConfig`. Is disabled by default and can be enabled. We need to deploy the secret ourselves, that's why we need such an integration

Bumped to version `1.12.0` 