### PR TITLE
fix(charts): fix policy-reporter-ui backend name

### DIFF
--- a/charts/policy-reporter/charts/ui/templates/_helpers.tpl
+++ b/charts/policy-reporter/charts/ui/templates/_helpers.tpl
@@ -77,7 +77,9 @@ Create the name of the service account to use
 {{- $name := .Chart.Name }}
 {{- if .Values.global.fullnameOverride }}
 {{- .Values.global.fullnameOverride }}
+{{- else if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- .Values.global.backend }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}

--- a/charts/policy-reporter/charts/ui/templates/_helpers.tpl
+++ b/charts/policy-reporter/charts/ui/templates/_helpers.tpl
@@ -75,7 +75,9 @@ Create the name of the service account to use
 
 {{- define "ui.policyReportServiceName" -}}
 {{- $name := .Chart.Name }}
-{{- if .Values.global.fullnameOverride }}
+{{- if .Values.global.backend }}
+{{- .Values.global.backend }}
+{{- else if .Values.global.fullnameOverride }}
 {{- .Values.global.fullnameOverride }}
 {{- else if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -99,8 +99,8 @@ global:
   plugins:
     # enable kyverno for Policy Reporter UI and monitoring
     keyverno: false
-  # The name of service policy-report. If you changed ReleaseName you have to replace it
-  backend: policy-reporter
+  # The name of service policy-report. Defaults to ReleaseName.
+  backend: ""
   # Service Port number
   port: 8080
   fullnameOverride: ""


### PR DESCRIPTION
Fixes https://github.com/kyverno/policy-reporter-kyverno-plugin/issues/7

If you deployed the helm chart with another release name, instead of policy-reporter, policy-reporter svc name differs from ui.backend which leads to policies not be available in UI because. I think the charts shouldn't have such dependency, and it should be possible to have different chart release name than only `policy-reporter` name.