### PR TITLE
fix(charts): fix to PR#85

### DIFF
--- a/charts/policy-reporter/charts/ui/templates/_helpers.tpl
+++ b/charts/policy-reporter/charts/ui/templates/_helpers.tpl
@@ -77,7 +77,9 @@ Create the name of the service account to use
 {{- $name := .Chart.Name }}
 {{- if .Values.global.fullnameOverride }}
 {{- .Values.global.fullnameOverride }}
+{{- else if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- .Values.global.backend }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}

--- a/charts/policy-reporter/charts/ui/templates/_helpers.tpl
+++ b/charts/policy-reporter/charts/ui/templates/_helpers.tpl
@@ -74,7 +74,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "ui.policyReportServiceName" -}}
-{{- $name := .Chart.Name }}
+{{- $name := "policy-reporter" }}
 {{- if .Values.global.backend }}
 {{- .Values.global.backend }}
 {{- else if .Values.global.fullnameOverride }}

--- a/charts/policy-reporter/charts/ui/templates/_helpers.tpl
+++ b/charts/policy-reporter/charts/ui/templates/_helpers.tpl
@@ -75,7 +75,9 @@ Create the name of the service account to use
 
 {{- define "ui.policyReportServiceName" -}}
 {{- $name := .Chart.Name }}
-{{- if .Values.global.fullnameOverride }}
+{{- if .Values.global.backend }}
+{{- .Values.global.backend }}
+{{- else if .Values.global.fullnameOverride }}
 {{- .Values.global.fullnameOverride }}
 {{- else if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -99,8 +99,8 @@ global:
   plugins:
     # enable kyverno for Policy Reporter UI and monitoring
     keyverno: false
-  # The name of service policy-report. If you changed ReleaseName you have to replace it
-  backend: policy-reporter
+  # The name of service policy-report. Defaults to ReleaseName.
+  backend: ""
   # Service Port number
   port: 8080
   fullnameOverride: ""


### PR DESCRIPTION
Fixes https://github.com/kyverno/policy-reporter/pull/85

Tests:

changes to values.yaml before test:
```
ui:
  enabled: true

kyvernoPlugin:
  enabled: true

global:
  plugins:
    keyverno: true
```

All service name and `-backend` flag targets must be the same, when:

ReleaseName = `policy-repoter`
```
$ helm install --dry-run --debug policy-reporter policy-reporter | grep "\-backend"
            - -backend=http://policy-reporter:8080
            
$ helm template policy-reporter  policy-reporter -s templates/service.yaml | yq ".metadata.name" 
"policy-reporter"
```

ReleaseName = policy-reporter-ui Chart.Name = `policy-repoter-ui`
```
$ helm install --dry-run --debug policy-reporter-ui policy-reporter | grep "\-backend"
            - -backend=http://policy-reporter-ui:8080

$ helm template policy-reporter-ui  policy-reporter -s templates/service.yaml | yq ".metadata.name"
"policy-reporter-ui"
```

ReleaseName = contains `policy-reporter` keyword with suffix
```
$ helm install --dry-run --debug policy-reporter-mysuffix policy-reporter | grep "\-backend"
            - -backend=http://policy-reporter-mysuffix:8080
$ helm template policy-reporter-mysuffix  policy-reporter -s templates/service.yaml | yq ".metadata.name"
"policy-reporter-mysuffix"
```

ReleaseName = contains `policy-reporter` keyword with prefix
```
$ helm install --dry-run --debug myprefix-policy-reporter policy-reporter | grep "\-backend"
            - -backend=http://myprefix-policy-reporter:8080
$ helm template myprefix-policy-reporter  policy-reporter -s templates/service.yaml | yq ".metadata.name"
"myprefix-policy-reporter"
```

ReleaseName =  contains `policy-reporter` keyword with both prefix and suffix
```
$ helm install --dry-run --debug myprefix-policy-reporter-mysuffix policy-reporter | grep "\-backend"
            - -backend=http://myprefix-policy-reporter-mysuffix:8080
$ helm template myprefix-policy-reporter-mysuffix  policy-reporter -s templates/service.yaml | yq ".metadata.name"
"myprefix-policy-reporter-mysuffix"
```
ReleaseName = does not contain `policy-reporter` keyword.
```
$ helm install --dry-run --debug alternative-name policy-reporter | grep "\-backend"
            - -backend=http://alternative-name-policy-reporter:8080
$ helm template alternative-name policy-reporter -s templates/service.yaml | yq ".metadata.name"
"alternative-name-policy-reporter"            
```

