### PR TITLE
fix: Replace wildcard in clusterrole with actual permission

### DIFF
--- a/charts/policy-reporter/templates/clusterrole.yaml
+++ b/charts/policy-reporter/templates/clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - wgpolicyk8s.io
   resources:
   - policyreports
   - policyreports/status

--- a/charts/policy-reporter/templates/plugins/kyverno/clusterrole.yaml
+++ b/charts/policy-reporter/templates/plugins/kyverno/clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ include "kyverno-plugin.fullname" . }}
 rules:
 - apiGroups:
-  - '*'
+  - kyverno.io
   resources:
   - policies
   - policies/status
@@ -28,7 +28,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - wgpolicyk8s.io
   resources:
   - policyreports
   - policyreports/status

--- a/manifests/policy-reporter-kyverno-ui-ha/install.yaml
+++ b/manifests/policy-reporter-kyverno-ui-ha/install.yaml
@@ -174,7 +174,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - wgpolicyk8s.io
   resources:
   - policyreports
   - policyreports/status
@@ -223,7 +223,7 @@ metadata:
   name: policy-reporter-kyverno-plugin
 rules:
 - apiGroups:
-  - '*'
+  - kyverno.io
   resources:
   - policies
   - policies/status

--- a/manifests/policy-reporter-kyverno-ui/install.yaml
+++ b/manifests/policy-reporter-kyverno-ui/install.yaml
@@ -122,7 +122,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - wgpolicyk8s.io
   resources:
   - policyreports
   - policyreports/status
@@ -171,7 +171,7 @@ metadata:
   name: policy-reporter-kyverno-plugin
 rules:
 - apiGroups:
-  - '*'
+  - kyverno.io
   resources:
   - policies
   - policies/status

--- a/manifests/policy-reporter-ui/install.yaml
+++ b/manifests/policy-reporter-ui/install.yaml
@@ -95,7 +95,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - wgpolicyk8s.io
   resources:
   - policyreports
   - policyreports/status

--- a/manifests/policy-reporter/install.yaml
+++ b/manifests/policy-reporter/install.yaml
@@ -53,7 +53,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - '*'
+  - wgpolicyk8s.io
   resources:
   - policyreports
   - policyreports/status


### PR DESCRIPTION
Resolves #1177

I ran `make codegen-static-manifests` but it produced a lot of other changes related the release 3.5.0:
```diff
diff --git a/manifests/policy-reporter-kyverno-ui-ha/install.yaml b/manifests/policy-reporter-kyverno-ui-ha/install.yaml
index a179f80..658cd0e 100644
--- a/manifests/policy-reporter-kyverno-ui-ha/install.yaml
+++ b/manifests/policy-reporter-kyverno-ui-ha/install.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: policy-reporter-kyverno-plugin
     app.kubernetes.io/instance: policy-reporter
-    app.kubernetes.io/version: "3.4.2"
+    app.kubernetes.io/version: "3.5.0"
 spec:
   minAvailable: 1
   selector:
@@ -24,7 +24,7 @@ metadata:
   labels:
     app.kubernetes.io/name: policy-reporter
     app.kubernetes.io/instance: policy-reporter
-    app.kubernetes.io/version: "3.4.2"
+    app.kubernetes.io/version: "3.5.0"
     app.kubernetes.io/component: reporting
     app.kubernetes.io/part-of: policy-reporter
 spec:
@@ -43,7 +43,7 @@ metadata:
   labels:
     app.kubernetes.io/name: policy-reporter-ui
     app.kubernetes.io/instance: policy-reporter
-    app.kubernetes.io/version: "3.4.2"
+    app.kubernetes.io/version: "3.5.0"
```

Shall I stage those changes as well?

/cc: @blanchardma @the-technat @asdfgugus @LinoSteffen