### PR TITLE
feat(chart): add Gateway API HTTPRoute support

### DIFF
--- a/charts/policy-reporter/Chart.yaml
+++ b/charts/policy-reporter/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
 type: application
-version: 3.5.0
+version: 3.6.0
 appVersion: 3.5.0
 
 icon: https://github.com/kyverno/kyverno/raw/main/img/logo.png

--- a/charts/policy-reporter/README.md
+++ b/charts/policy-reporter/README.md
@@ -3,7 +3,7 @@
 Policy Reporter watches for PolicyReport Resources.
 It creates Prometheus Metrics and can send rule validation events to different targets like Loki, Elasticsearch, Slack or Discord
 
-![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.0](https://img.shields.io/badge/AppVersion-3.5.0-informational?style=flat-square)
+![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.0](https://img.shields.io/badge/AppVersion-3.5.0-informational?style=flat-square)
 
 ## Documentation
 
@@ -87,6 +87,12 @@ Open `http://localhost:8082/` in your browser.
 | ingress.annotations | object | `{}` | Annotations for the Ingress |
 | ingress.hosts | string | `nil` | Ingress host list |
 | ingress.tls | list | `[]` | Ingress tls list |
+| httproute.enabled | bool | `false` | Enable HTTPRoute resource (Gateway API alternative to Ingress) Requires Gateway API CRDs (v1) installed in cluster https://gateway-api.sigs.k8s.io/ |
+| httproute.labels | object | `{}` | Additional HTTPRoute labels |
+| httproute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| httproute.parentRefs | list | `[]` | Gateway API parentRefs (list of Gateway references) Must reference an existing Gateway resource |
+| httproute.hostnames | list | `[]` | List of hostnames for HTTPRoute |
+| httproute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | HTTPRoute rules configuration Allows advanced routing with matches and filters |
 | logging.server | bool | `false` | Enables server access logging |
 | logging.encoding | string | `"console"` | Log encoding possible encodings are console and json |
 | logging.logLevel | int | `0` | Log level default info |
@@ -99,14 +105,10 @@ Open `http://localhost:8082/` in your browser.
 | worker | int | `5` | Amount of queue workers for Report resource processing |
 | reportFilter | object | `{}` | Filter Report resources to process |
 | sourceConfig | list | `[]` | Customize source specific logic like result ID generation |
-| sourceFilters[0].selector.source | string | `"kyverno"` | select Report by source |
+| sourceFilters[0].selector.sources | list | `["kyverno","KyvernoValidatingPolicy","KyvernoImageValidatingPolicy"]` | select Report by source |
 | sourceFilters[0].uncontrolledOnly | bool | `true` | Filter out Reports of controlled Pods and Jobs, only works for Reports with scope resource |
 | sourceFilters[0].disableClusterReports | bool | `false` | Filter out cluster scoped Reports |
 | sourceFilters[0].kinds | object | `{"exclude":["ReplicaSet"]}` | Filter out Reports based on the scope resource kind |
-| sourceFilters[1].selector.source | string | `"KyvernoValidatingPolicy"` | select Report by source |
-| sourceFilters[1].uncontrolledOnly | bool | `true` | Filter out Reports of controlled Pods and Jobs, only works for Reports with scope resource |
-| sourceFilters[1].disableClusterReports | bool | `false` | Filter out cluster scoped Reports |
-| sourceFilters[1].kinds | object | `{"exclude":["ReplicaSet"]}` | Filter out Reports based on the scope resource kind |
 | global.labels | object | `{}` | additional labels added on each resource |
 | basicAuth.username | string | `""` | HTTP BasicAuth username |
 | basicAuth.password | string | `""` | HTTP BasicAuth password |
@@ -459,6 +461,12 @@ Open `http://localhost:8082/` in your browser.
 | ui.ingress.annotations | object | `{}` | Ingress annotations. |
 | ui.ingress.hosts | list | `[]` | List of ingress host configurations. |
 | ui.ingress.tls | list | `[]` | List of ingress TLS configurations. |
+| ui.httproute.enabled | bool | `false` | Enable HTTPRoute resource (Gateway API alternative to Ingress) Requires Gateway API CRDs (v1) installed in cluster https://gateway-api.sigs.k8s.io/ |
+| ui.httproute.labels | object | `{}` | Additional HTTPRoute labels |
+| ui.httproute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| ui.httproute.parentRefs | list | `[]` | Gateway API parentRefs (list of Gateway references) Must reference an existing Gateway resource |
+| ui.httproute.hostnames | list | `[]` | List of hostnames for HTTPRoute |
+| ui.httproute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | HTTPRoute rules configuration Allows advanced routing with matches and filters |
 | ui.networkPolicy.enabled | bool | `false` | When true, use a NetworkPolicy to allow ingress to the webhook This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup. |
 | ui.networkPolicy.egress | list | `[{"ports":[{"port":6443,"protocol":"TCP"}]}]` | A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies. Enables Kubernetes API Server by default |
 | ui.networkPolicy.ingress | list | `[]` | A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies. |
@@ -523,6 +531,12 @@ Open `http://localhost:8082/` in your browser.
 | plugin.kyverno.networkPolicy.enabled | bool | `false` | When true, use a NetworkPolicy to allow ingress to the webhook This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup. |
 | plugin.kyverno.networkPolicy.egress | list | `[{"ports":[{"port":6443,"protocol":"TCP"}]}]` | A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies. Enables Kubernetes API Server by default |
 | plugin.kyverno.networkPolicy.ingress | list | `[]` | A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies. |
+| plugin.kyverno.httproute.enabled | bool | `false` | Enable HTTPRoute resource (Gateway API alternative to Ingress) Requires Gateway API CRDs (v1) installed in cluster https://gateway-api.sigs.k8s.io/ |
+| plugin.kyverno.httproute.labels | object | `{}` | Additional HTTPRoute labels |
+| plugin.kyverno.httproute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| plugin.kyverno.httproute.parentRefs | list | `[]` | Gateway API parentRefs (list of Gateway references) Must reference an existing Gateway resource |
+| plugin.kyverno.httproute.hostnames | list | `[]` | List of hostnames for HTTPRoute |
+| plugin.kyverno.httproute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | HTTPRoute rules configuration Allows advanced routing with matches and filters |
 | plugin.kyverno.resources | object | `{}` | Resource constraints |
 | plugin.kyverno.leaderElection.lockName | string | `"kyverno-plugin"` | Lock Name |
 | plugin.kyverno.leaderElection.releaseOnCancel | bool | `true` | Released lock when the run context is cancelled. |
@@ -679,4 +693,4 @@ Open `http://localhost:8082/` in your browser.
 | Ammar Yasser |  |  |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/policy-reporter/templates/httproute.yaml
+++ b/charts/policy-reporter/templates/httproute.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "policyreporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "policyreporter.namespace" . }}
+  labels:
+    {{- include "policyreporter.labels" . | nindent 4 }}
+    {{- if .Values.httproute.labels }}
+    {{- with .Values.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+  {{- if or .Values.annotations .Values.httproute.annotations }}
+  annotations:
+  {{- with .Values.httproute.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httproute.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/policy-reporter/templates/plugins/kyverno/httproute.yaml
+++ b/charts/policy-reporter/templates/plugins/kyverno/httproute.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.plugin.kyverno.enabled -}}
+{{- if .Values.plugin.kyverno.httproute.enabled -}}
+{{- $fullName := include "kyverno-plugin.fullname" . -}}
+{{- $svcPort := .Values.plugin.kyverno.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "policyreporter.namespace" . }}
+  labels:
+    {{- include "kyverno-plugin.labels" . | nindent 4 }}
+    {{- with .Values.plugin.kyverno.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.plugin.kyverno.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.plugin.kyverno.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.plugin.kyverno.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.plugin.kyverno.httproute.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/policy-reporter/templates/ui/httproute.yaml
+++ b/charts/policy-reporter/templates/ui/httproute.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ui.enabled -}}
+{{- if .Values.ui.httproute.enabled -}}
+{{- $fullName := include "ui.fullname" . -}}
+{{- $svcPort := .Values.ui.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ include "policyreporter.namespace" . }}
+  labels:
+    {{- include "ui.labels" . | nindent 4 }}
+    {{- with .Values.ui.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ui.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ui.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ui.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ui.httproute.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -134,6 +134,39 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+httproute:
+  # -- Enable HTTPRoute resource (Gateway API alternative to Ingress)
+  # Requires Gateway API CRDs (v1) installed in cluster
+  # https://gateway-api.sigs.k8s.io/
+  enabled: false
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Gateway API parentRefs (list of Gateway references)
+  # Must reference an existing Gateway resource
+  parentRefs: []
+  #  - name: example-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # -- List of hostnames for HTTPRoute
+  hostnames: []
+  #  - policy-reporter.example.com
+  # -- HTTPRoute rules configuration
+  # Allows advanced routing with matches and filters
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # Optional filters:
+      # filters:
+      #   - type: RequestHeaderModifier
+      #     requestHeaderModifier:
+      #       add:
+      #         - name: X-Custom-Header
+      #           value: value
+
 logging:
   # -- Enables server access logging
   server: false
@@ -1229,6 +1262,39 @@ ui:
     #    hosts:
     #      - chart-example.local
 
+  httproute:
+    # -- Enable HTTPRoute resource (Gateway API alternative to Ingress)
+    # Requires Gateway API CRDs (v1) installed in cluster
+    # https://gateway-api.sigs.k8s.io/
+    enabled: false
+    # -- Additional HTTPRoute labels
+    labels: {}
+    # -- Additional HTTPRoute annotations
+    annotations: {}
+    # -- Gateway API parentRefs (list of Gateway references)
+    # Must reference an existing Gateway resource
+    parentRefs: []
+    #  - name: example-gateway
+    #    namespace: gateway-system
+    #    sectionName: https
+    # -- List of hostnames for HTTPRoute
+    hostnames: []
+    #  - policy-reporter-ui.example.com
+    # -- HTTPRoute rules configuration
+    # Allows advanced routing with matches and filters
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+        # Optional filters:
+        # filters:
+        #   - type: RequestHeaderModifier
+        #     requestHeaderModifier:
+        #       add:
+        #         - name: X-Custom-Header
+        #           value: value
+
   networkPolicy:
     # -- When true, use a NetworkPolicy to allow ingress to the webhook
     # This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup.
@@ -1440,6 +1506,39 @@ plugin:
           port: 6443
       # -- A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies.
       ingress: []
+
+    httproute:
+      # -- Enable HTTPRoute resource (Gateway API alternative to Ingress)
+      # Requires Gateway API CRDs (v1) installed in cluster
+      # https://gateway-api.sigs.k8s.io/
+      enabled: false
+      # -- Additional HTTPRoute labels
+      labels: {}
+      # -- Additional HTTPRoute annotations
+      annotations: {}
+      # -- Gateway API parentRefs (list of Gateway references)
+      # Must reference an existing Gateway resource
+      parentRefs: []
+      #  - name: example-gateway
+      #    namespace: gateway-system
+      #    sectionName: https
+      # -- List of hostnames for HTTPRoute
+      hostnames: []
+      #  - policy-reporter-kyverno-plugin.example.com
+      # -- HTTPRoute rules configuration
+      # Allows advanced routing with matches and filters
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          # Optional filters:
+          # filters:
+          #   - type: RequestHeaderModifier
+          #     requestHeaderModifier:
+          #       add:
+          #         - name: X-Custom-Header
+          #           value: value
 
     # -- Resource constraints
     resources: {}


### PR DESCRIPTION
## Summary
  Add Gateway API HTTPRoute support as an alternative to traditional Ingress resources for all three components: policy-reporter core, UI, and Kyverno 
  plugin.

  ## Changes
  - Add HTTPRoute templates for core, UI, and Kyverno plugin
  - Add httproute configuration sections to values.yaml
  - Support Gateway API v1 (stable) with custom rules, matches, and filters
  - Update chart version to 3.6.0

  ## Features
  - HTTPRoute resources as alternative to Ingress
  - Support for multiple Gateway parentRefs
  - Custom hostnames configuration
  - Advanced routing rules with matches and filters
  - Disabled by default for backward compatibility