### PR TITLE
Include PolicyReport name and namespace as labels in alerts sent to AlertManager

### DIFF
--- a/pkg/listener/send_result.go
+++ b/pkg/listener/send_result.go
@@ -34,7 +34,7 @@ func NewSendResultListener(targets *target.Collection) report.PolicyReportResult
 					return
 				}
 
-				target.Send(result)
+				target.Send(re, result)
 			}(t, rep, r, e)
 		}
 

--- a/pkg/listener/send_result_test.go
+++ b/pkg/listener/send_result_test.go
@@ -21,7 +21,7 @@ type client struct {
 	cleanup               bool
 }
 
-func (c *client) Send(result openreports.ResultAdapter) {
+func (c *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	c.Called = true
 }
 

--- a/pkg/target/client.go
+++ b/pkg/target/client.go
@@ -26,7 +26,7 @@ const (
 // Client for a provided Target
 type Client interface {
 	// Send the given Result to the configured Target
-	Send(result openreports.ResultAdapter)
+	Send(report openreports.ReportInterface, result openreports.ResultAdapter)
 	// BatchSend the given Results of a single PolicyReport to the configured Target
 	BatchSend(report openreports.ReportInterface, results []openreports.ResultAdapter)
 	// SkipExistingOnStartup skips already existing PolicyReportResults on startup

--- a/pkg/target/discord/discord.go
+++ b/pkg/target/discord/discord.go
@@ -106,7 +106,7 @@ type client struct {
 	client       http.Client
 }
 
-func (d *client) Send(result openreports.ResultAdapter) {
+func (d *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	req, err := http.CreateJSONRequest("POST", d.webhook, newPayload(result, d.customFields))
 	if err != nil {
 		return

--- a/pkg/target/discord/discord_test.go
+++ b/pkg/target/discord/discord_test.go
@@ -45,7 +45,7 @@ func Test_LokiTarget(t *testing.T) {
 			Webhook:    "http://hook.discord:80",
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 
 	t.Run("Send Minimal Result", func(t *testing.T) {
@@ -70,7 +70,7 @@ func Test_LokiTarget(t *testing.T) {
 			Webhook:    "http://hook.discord:80",
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.MinimalTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.MinimalTargetSendResult)
 	})
 	t.Run("Name", func(t *testing.T) {
 		client := discord.NewClient(discord.Options{

--- a/pkg/target/elasticsearch/elasticsearch.go
+++ b/pkg/target/elasticsearch/elasticsearch.go
@@ -50,7 +50,7 @@ type client struct {
 	typelessApi bool
 }
 
-func (e *client) Send(result openreports.ResultAdapter) {
+func (e *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	var host string
 	var apiSuffix string
 	if e.typelessApi {

--- a/pkg/target/elasticsearch/elasticsearch_test.go
+++ b/pkg/target/elasticsearch/elasticsearch_test.go
@@ -56,7 +56,7 @@ func Test_ElasticsearchTarget(t *testing.T) {
 			HTTPClient:   testClient{callback, 200},
 			CustomFields: map[string]string{"cluster": "name"},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 
 		if len(fixtures.CompleteTargetSendResult.Properties) > 1 {
 			t.Error("expected customFields are not added to the actuel result")
@@ -82,7 +82,7 @@ func Test_ElasticsearchTarget(t *testing.T) {
 			Rotation:   elasticsearch.Monthly,
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 	t.Run("Send with Monthly Result", func(t *testing.T) {
 		callback := func(req *http.Request) {
@@ -100,7 +100,7 @@ func Test_ElasticsearchTarget(t *testing.T) {
 			Rotation:   elasticsearch.Daily,
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 	t.Run("Send with None Result", func(t *testing.T) {
 		callback := func(req *http.Request) {
@@ -118,7 +118,7 @@ func Test_ElasticsearchTarget(t *testing.T) {
 			Rotation:   elasticsearch.None,
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 	t.Run("Name", func(t *testing.T) {
 		client := elasticsearch.NewClient(elasticsearch.Options{

--- a/pkg/target/gcs/gcs.go
+++ b/pkg/target/gcs/gcs.go
@@ -29,7 +29,7 @@ type client struct {
 	prefix       string
 }
 
-func (c *client) Send(result openreports.ResultAdapter) {
+func (c *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	if len(c.customFields) > 0 {
 		props := make(map[string]string, 0)
 

--- a/pkg/target/gcs/gcs_test.go
+++ b/pkg/target/gcs/gcs_test.go
@@ -42,7 +42,7 @@ func Test_GCSTarget(t *testing.T) {
 			CustomFields: map[string]string{"cluster": "name"},
 			Client:       &testClient{nil, callback},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 
 		if len(fixtures.CompleteTargetSendResult.Properties) > 1 || fixtures.CompleteTargetSendResult.Properties["cluster"] != "" {
 			t.Error("expected customFields are not added to the actuel result")

--- a/pkg/target/googlechat/googlechat.go
+++ b/pkg/target/googlechat/googlechat.go
@@ -185,7 +185,7 @@ func mapPayload(result openreports.ResultAdapter) (*Payload, error) {
 	}, nil
 }
 
-func (e *client) Send(result openreports.ResultAdapter) {
+func (e *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	if len(e.customFields) > 0 {
 		props := make(map[string]string, 0)
 

--- a/pkg/target/googlechat/googlechat_test.go
+++ b/pkg/target/googlechat/googlechat_test.go
@@ -56,7 +56,7 @@ func Test_GoogleChatTarget(t *testing.T) {
 			CustomFields: map[string]string{"cluster": "name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 
 		if len(fixtures.CompleteTargetSendResult.Properties) > 1 || fixtures.CompleteTargetSendResult.Properties["cluster"] != "" {
 			t.Error("expected customFields are not added to the actuel result")

--- a/pkg/target/jira/jira.go
+++ b/pkg/target/jira/jira.go
@@ -54,7 +54,7 @@ type client struct {
 	jiraV3          *v3.Client
 }
 
-func (e *client) Send(result openreports.ResultAdapter) {
+func (e *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	var summary bytes.Buffer
 
 	t, err := template.New("summary").Parse(e.summaryTemplate)

--- a/pkg/target/jira/jira_test.go
+++ b/pkg/target/jira/jira_test.go
@@ -88,7 +88,7 @@ func Test_JiraTarget(t *testing.T) {
 			CustomFields: map[string]string{"customfield_10001": "PolicyReporter"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 
 	t.Run("Send Minimal Result", func(t *testing.T) {
@@ -151,7 +151,7 @@ func Test_JiraTarget(t *testing.T) {
 			SummaryTemplate: "{{ customfield.cluster }}: Policy Violation: {{ result.Policy }}",
 		})
 		if assert.NoError(t, err) {
-			client.Send(fixtures.CompleteTargetSendResult)
+			client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 		}
 	})
 
@@ -183,7 +183,7 @@ func Test_JiraTarget(t *testing.T) {
 			IssueType:  "", // Empty to test default
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 
 	t.Run("Custom Fields", func(t *testing.T) {
@@ -218,7 +218,7 @@ func Test_JiraTarget(t *testing.T) {
 			},
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 
 	t.Run("Name", func(t *testing.T) {

--- a/pkg/target/kinesis/kinesis.go
+++ b/pkg/target/kinesis/kinesis.go
@@ -27,7 +27,7 @@ type client struct {
 	kinesis      aws.Client
 }
 
-func (c *client) Send(result openreports.ResultAdapter) {
+func (c *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	if len(c.customFields) > 0 {
 		props := make(map[string]string, 0)
 

--- a/pkg/target/kinesis/kinesis_test.go
+++ b/pkg/target/kinesis/kinesis_test.go
@@ -46,7 +46,7 @@ func Test_KinesisTarget(t *testing.T) {
 			CustomFields: map[string]string{"cluster": "name"},
 			Kinesis:      &testClient{nil, callback},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 
 		if len(fixtures.CompleteTargetSendResult.Properties) > 1 || fixtures.CompleteTargetSendResult.Properties["cluster"] != "" {
 			t.Error("expected customFields are not added to the actuel result")

--- a/pkg/target/loki/loki.go
+++ b/pkg/target/loki/loki.go
@@ -101,7 +101,7 @@ type client struct {
 	password     string
 }
 
-func (l *client) Send(result openreports.ResultAdapter) {
+func (l *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	l.send(Payload{
 		Streams: []Stream{
 			newLokiStream(result, l.customFields),

--- a/pkg/target/loki/loki_test.go
+++ b/pkg/target/loki/loki_test.go
@@ -67,7 +67,7 @@ func Test_LokiTarget(t *testing.T) {
 			Password:     "password",
 			Headers:      map[string]string{"X-Forward": "http://loki"},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 
 	t.Run("Send Minimal Result", func(t *testing.T) {
@@ -97,7 +97,7 @@ func Test_LokiTarget(t *testing.T) {
 			CustomFields: map[string]string{"custom": "label"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.MinimalTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.MinimalTargetSendResult)
 	})
 	t.Run("Name", func(t *testing.T) {
 		client := loki.NewClient(loki.Options{

--- a/pkg/target/s3/s3.go
+++ b/pkg/target/s3/s3.go
@@ -29,7 +29,7 @@ type client struct {
 	prefix       string
 }
 
-func (c *client) Send(result openreports.ResultAdapter) {
+func (c *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	if len(c.customFields) > 0 {
 		props := make(map[string]string, 0)
 

--- a/pkg/target/s3/s3_test.go
+++ b/pkg/target/s3/s3_test.go
@@ -42,7 +42,7 @@ func Test_S3Target(t *testing.T) {
 			CustomFields: map[string]string{"cluster": "name"},
 			S3:           &testClient{nil, callback},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 
 		if len(fixtures.CompleteTargetSendResult.Properties) > 1 || fixtures.CompleteTargetSendResult.Properties["cluster"] != "" {
 			t.Error("expected customFields are not added to the actuel result")

--- a/pkg/target/securityhub/securityhub.go
+++ b/pkg/target/securityhub/securityhub.go
@@ -112,7 +112,7 @@ func (c *client) mapFindings(polr openreports.ReportInterface, results []openrep
 	})
 }
 
-func (c *client) Send(result openreports.ResultAdapter) {
+func (c *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	c.BatchSend(&openreports.ReportAdapter{Report: &v1alpha1.Report{}}, []openreports.ResultAdapter{result})
 }
 

--- a/pkg/target/securityhub/securityhub_test.go
+++ b/pkg/target/securityhub/securityhub_test.go
@@ -82,7 +82,7 @@ func TestSecurityHub(t *testing.T) {
 			},
 		})
 
-		c.Send(fixtures.CompleteTargetSendResult)
+		c.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 	t.Run("clean up disabled", func(t *testing.T) {
 		h := &client{}

--- a/pkg/target/slack/slack.go
+++ b/pkg/target/slack/slack.go
@@ -277,14 +277,14 @@ func (s *client) batchMessage(polr openreports.ReportInterface, results []openre
 	return p
 }
 
-func (s *client) Send(result openreports.ResultAdapter) {
+func (s *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	s.PostMessage(s.message(result))
 }
 
 func (s *client) BatchSend(report openreports.ReportInterface, results []openreports.ResultAdapter) {
 	if report.GetScope() == nil {
 		for _, result := range results {
-			s.Send(result)
+			s.Send(report, result)
 		}
 
 		return

--- a/pkg/target/slack/slack_test.go
+++ b/pkg/target/slack/slack_test.go
@@ -46,7 +46,7 @@ func Test_SlackTarget(t *testing.T) {
 			CustomFields: map[string]string{"Cluster": "Name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 
 	t.Run("Send Minimal Result", func(t *testing.T) {
@@ -71,7 +71,7 @@ func Test_SlackTarget(t *testing.T) {
 			Webhook:    "http://hook.slack:80",
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.MinimalTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.MinimalTargetSendResult)
 	})
 
 	t.Run("Send enforce Result", func(t *testing.T) {
@@ -96,7 +96,7 @@ func Test_SlackTarget(t *testing.T) {
 			Webhook:    "http://hook.slack:80",
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.EnforceTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.EnforceTargetSendResult)
 	})
 
 	t.Run("Send incomplete Result", func(t *testing.T) {
@@ -122,7 +122,7 @@ func Test_SlackTarget(t *testing.T) {
 			CustomFields: map[string]string{"Cluster": "Name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.MissingUIDSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.MissingUIDSendResult)
 	})
 
 	t.Run("Send incomplete Result2", func(t *testing.T) {
@@ -148,7 +148,7 @@ func Test_SlackTarget(t *testing.T) {
 			CustomFields: map[string]string{"Cluster": "Name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.MissingAPIVersionSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.MissingAPIVersionSendResult)
 	})
 
 	t.Run("Name", func(t *testing.T) {

--- a/pkg/target/splunk/splunk.go
+++ b/pkg/target/splunk/splunk.go
@@ -35,7 +35,7 @@ type client struct {
 	token        string
 }
 
-func (c *client) Send(result openreports.ResultAdapter) {
+func (c *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	c.sendAndLogResult(splunkRequest{
 		Event:      http.NewJSONResult(result),
 		SourceType: policyReporterSource,

--- a/pkg/target/splunk/splunk_test.go
+++ b/pkg/target/splunk/splunk_test.go
@@ -47,6 +47,6 @@ func TestSplunkTarget(t *testing.T) {
 			Headers:    map[string]string{"Authorization": "Splunk my-token"},
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 }

--- a/pkg/target/teams/teams.go
+++ b/pkg/target/teams/teams.go
@@ -31,7 +31,7 @@ type client struct {
 	client       http.Client
 }
 
-func (s *client) Send(result openreports.ResultAdapter) {
+func (s *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	s.PostMessage(s.newMessage(result.GetResource(), []openreports.ResultAdapter{result}))
 }
 
@@ -40,7 +40,7 @@ func (s *client) CleanUp(_ context.Context, _ openreports.ReportInterface) {}
 func (s *client) BatchSend(report openreports.ReportInterface, results []openreports.ResultAdapter) {
 	if report.GetScope() == nil {
 		for idx := range results {
-			s.Send(results[idx])
+			s.Send(report, results[idx])
 		}
 	}
 

--- a/pkg/target/teams/teams_test.go
+++ b/pkg/target/teams/teams_test.go
@@ -48,7 +48,7 @@ func Test_TeamsTarget(t *testing.T) {
 			CustomFields: map[string]string{"Cluster": "Name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 
 	t.Run("Send Minimal Result", func(t *testing.T) {
@@ -71,7 +71,7 @@ func Test_TeamsTarget(t *testing.T) {
 			CustomFields: map[string]string{"Cluster": "Name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.MinimalTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.MinimalTargetSendResult)
 	})
 	t.Run("Send Minimal InfoResult", func(t *testing.T) {
 		callback := func(req *http.Request) {
@@ -89,7 +89,7 @@ func Test_TeamsTarget(t *testing.T) {
 			CustomFields: map[string]string{"Cluster": "Name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.InfoSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.InfoSendResult)
 	})
 	t.Run("Send Minimal ErrorResult", func(t *testing.T) {
 		callback := func(req *http.Request) {
@@ -107,7 +107,7 @@ func Test_TeamsTarget(t *testing.T) {
 			CustomFields: map[string]string{"Cluster": "Name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.ErrorSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.ErrorSendResult)
 	})
 	t.Run("Send Minimal Debug Result", func(t *testing.T) {
 		callback := func(req *http.Request) {
@@ -129,7 +129,7 @@ func Test_TeamsTarget(t *testing.T) {
 			CustomFields: map[string]string{"Cluster": "Name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.DebugSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.DebugSendResult)
 	})
 	t.Run("Name", func(t *testing.T) {
 		client := teams.NewClient(teams.Options{

--- a/pkg/target/telegram/telegram.go
+++ b/pkg/target/telegram/telegram.go
@@ -84,7 +84,7 @@ type client struct {
 	client       http.Client
 }
 
-func (e *client) Send(result openreports.ResultAdapter) {
+func (e *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	if len(e.customFields) > 0 {
 		props := make(map[string]string, 0)
 

--- a/pkg/target/telegram/telegram_test.go
+++ b/pkg/target/telegram/telegram_test.go
@@ -56,7 +56,7 @@ func Test_TelegramTarget(t *testing.T) {
 			CustomFields: map[string]string{"cluster": "name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 
 		if len(fixtures.CompleteTargetSendResult.Properties) > 1 || fixtures.CompleteTargetSendResult.Properties["cluster"] != "" {
 			t.Error("expected customFields are not added to the actuel result")

--- a/pkg/target/webhook/webhook.go
+++ b/pkg/target/webhook/webhook.go
@@ -30,7 +30,7 @@ type client struct {
 	keepalive    *v1alpha1.KeepaliveConfig
 }
 
-func (e *client) Send(result openreports.ResultAdapter) {
+func (e *client) Send(report openreports.ReportInterface, result openreports.ResultAdapter) {
 	if len(e.customFields) > 0 {
 		props := make(map[string]string, 0)
 

--- a/pkg/target/webhook/webhook_test.go
+++ b/pkg/target/webhook/webhook_test.go
@@ -56,7 +56,7 @@ func Test_UITarget(t *testing.T) {
 			CustomFields: map[string]string{"cluster": "name"},
 			HTTPClient:   testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 
 		if len(fixtures.CompleteTargetSendResult.Properties) > 1 || fixtures.CompleteTargetSendResult.Properties["cluster"] != "" {
 			t.Error("expected customFields are not added to the actuel result")
@@ -90,6 +90,6 @@ func Test_UITarget(t *testing.T) {
 			Host:       "\\localhost:8080",
 			HTTPClient: testClient{callback, 200},
 		})
-		client.Send(fixtures.CompleteTargetSendResult)
+		client.Send(fixtures.DefaultPolicyReport, fixtures.CompleteTargetSendResult)
 	})
 }

--- a/test/alertmanager/main.go
+++ b/test/alertmanager/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
 
 	"github.com/kyverno/policy-reporter/pkg/openreports"
@@ -13,6 +15,16 @@ import (
 )
 
 func main() {
+
+	// Create a partial test report
+	report := v1alpha1.Report{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-report",
+			Namespace: "test-namespace",
+		},
+	}
+
 	// Create a test result
 	result := v1alpha1.ReportResult{
 		Description: "Test policy violation from manual test",
@@ -48,7 +60,7 @@ func main() {
 
 	// Send the test alert
 	fmt.Println("Sending test alert to", alertManagerURL)
-	client.Send(&openreports.ReportAdapter{Report: &v1alpha1.Report{}}, openreports.ResultAdapter{ReportResult: result})
+	client.Send(&openreports.ReportAdapter{Report: &report}, openreports.ResultAdapter{ReportResult: result})
 
 	// Also test batch send
 	results := []openreports.ResultAdapter{
@@ -75,7 +87,7 @@ func main() {
 	}
 
 	fmt.Println("Sending batch test alerts")
-	client.BatchSend(nil, results)
+	client.BatchSend(&openreports.ReportAdapter{Report: &report}, results)
 
 	// Wait a moment to ensure alerts are sent before the program exits
 	time.Sleep(500 * time.Millisecond)

--- a/test/alertmanager/main.go
+++ b/test/alertmanager/main.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kyverno/policy-reporter/pkg/openreports"
 	"github.com/kyverno/policy-reporter/pkg/target"
@@ -15,7 +14,6 @@ import (
 )
 
 func main() {
-
 	// Create a partial test report
 	report := v1alpha1.Report{
 		TypeMeta: metav1.TypeMeta{},

--- a/test/alertmanager/main.go
+++ b/test/alertmanager/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	// Send the test alert
 	fmt.Println("Sending test alert to", alertManagerURL)
-	client.Send(openreports.ResultAdapter{ReportResult: result})
+	client.Send(&openreports.ReportAdapter{Report: &v1alpha1.Report{}}, openreports.ResultAdapter{ReportResult: result})
 
 	// Also test batch send
 	results := []openreports.ResultAdapter{


### PR DESCRIPTION
## Description

This PR adresses feature request #1240

## Changes summary

* Update the Send method signature in the Target Client interface to include ReportInterface as an argument (similar to BatchSend)
* Update Target implementations to honor the interface
* Update the `send_results_listener` to send the report with each result
* Use the report argument in AlertManager implementation to add name and namespaces as labels
* Update the tests

## Test

```text
curl http://localhost:9093/api/v2/alerts

[
  // ...
  {
    "annotations": {
      // ...
    },
    "endsAt": "2025-10-30T11:33:32.169-04:00",
    "fingerprint": "01aee9770a1cc8f2",
    "receivers": [
      // ...
    ],
    "startsAt": "2025-10-29T11:33:32.169-04:00",
    "status": {
      // ...
    },
    "updatedAt": "2025-10-29T15:33:32.248Z",
    "labels": {
      "alertname": "PolicyReporterViolation",
      "name": "trivy-vuln-polr-replicaset-echo-5d89b66b85",  // <-- new label
      "namespace": "abc",  // <-- new label
      "policy": "CVE-2024-52798",
      "severity": "high",
      "source": "Trivy Vulnerability",
      "status": "fail"
    }
  }
]
```
