### PR TITLE
feat: Add UID to Overview dashboard settings

### DIFF
--- a/charts/policy-reporter/templates/monitoring/overview.dashboard.yaml
+++ b/charts/policy-reporter/templates/monitoring/overview.dashboard.yaml
@@ -686,6 +686,7 @@ data:
     },
     "timezone": "",
     "title": "PolicyReports",
+    "uid": "BwFdLVeHJ",
     "version": 1
     }
 {{- end }}


### PR DESCRIPTION
## Description

This PR adds a `uid` field to the Overview dashboard. The other dashboards do provide a UID, but the overview one didn't until now.

This may not be of bit impact to many people but makes dashboard access across multiple instances consistent.
