### PR TITLE
chart: make selector labels for reporter, kyverno and trivy plugin services configurable as for UI part

### DIFF
--- a/charts/policy-reporter/templates/_helpers.tpl
+++ b/charts/policy-reporter/templates/_helpers.tpl
@@ -59,8 +59,12 @@ helm.sh/chart: {{ include "policyreporter.chart" . }}
 Selector labels
 */}}
 {{- define "policyreporter.selectorLabels" -}}
+{{- if .Values.selectorLabels }}
+{{- toYaml .Values.selectorLabels }}
+{{- else -}}
 app.kubernetes.io/name: policy-reporter
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/policy-reporter/templates/plugins/kyverno/_helpers.tpl
+++ b/charts/policy-reporter/templates/plugins/kyverno/_helpers.tpl
@@ -42,8 +42,12 @@ helm.sh/chart: {{ include "kyverno-plugin.chart" . }}
 Selector labels
 */}}
 {{- define "kyverno-plugin.selectorLabels" -}}
+{{- if .Values.plugin.kyverno.selectorLabels }}
+{{- toYaml .Values.plugin.kyverno.selectorLabels }}
+{{- else -}}
 app.kubernetes.io/name: {{ include "kyverno-plugin.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/policy-reporter/templates/plugins/trivy/_helpers.tpl
+++ b/charts/policy-reporter/templates/plugins/trivy/_helpers.tpl
@@ -42,8 +42,12 @@ helm.sh/chart: {{ include "trivy-plugin.chart" . }}
 Selector labels
 */}}
 {{- define "trivy-plugin.selectorLabels" -}}
+{{- if .Values.plugin.trivy.selectorLabels }}
+{{- toYaml .Values.plugin.trivy.selectorLabels }}
+{{- else -}}
 app.kubernetes.io/name: {{ include "trivy-plugin.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -92,6 +92,9 @@ podAnnotations: {}
 # -- Additional labels to add to each pod
 podLabels: {}
 
+# -- Custom selector labels, overwrites the default set
+selectorLabels: {}
+
 # -- Resource constraints
 resources: {}
   # limits:
@@ -1432,6 +1435,9 @@ plugin:
     # -- Additional labels to add to each pod
     podLabels: {}
 
+    # -- Custom selector labels, overwrites the default set
+    selectorLabels: {}
+
     # -- Deployment update strategy.
     # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
     updateStrategy: {}
@@ -1703,6 +1709,9 @@ plugin:
 
     # -- Additional labels to add to each pod
     podLabels: {}
+
+    # -- Custom selector labels, overwrites the default set
+    selectorLabels: {}
 
     # -- Deployment update strategy.
     # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy


### PR DESCRIPTION
The proposed change follows the approach chosen for UI service' selector labels.

The need of this change is very niche: if one wants to have several policy reporter's plugins running in the same namespace, selectors have to be more granular and configurable.

Why one might need several reporters in the same namespace? This is needed when policy-reporter is deployed for monitoring multiple clusters without actually having the reporters running in remote clusters. This setup can work and works, but is quite complicated to achieve.

On the other hand, the change should be innocent and do not harm common cases.