### PR TITLE
remove resource uid from Loki output for improved loki bucket management

### DIFF
--- a/pkg/target/loki/loki.go
+++ b/pkg/target/loki/loki.go
@@ -69,9 +69,6 @@ func newLokiStream(result openreports.ResultAdapter, customFields map[string]str
 			labels["kind"] = res.Kind
 			labels["name"] = res.Name
 		}
-		if res.UID != "" {
-			labels["uid"] = string(res.UID)
-		}
 		if res.Namespace != "" {
 			labels["namespace"] = res.Namespace
 		}

--- a/pkg/target/loki/loki_test.go
+++ b/pkg/target/loki/loki_test.go
@@ -50,7 +50,6 @@ func Test_LokiTarget(t *testing.T) {
 			res := or.GetResource()
 			assert.Equal(t, res.Kind, stream.Stream["kind"])
 			assert.Equal(t, res.Name, stream.Stream["name"])
-			assert.Equal(t, string(res.UID), stream.Stream["uid"])
 			assert.Equal(t, res.Namespace, stream.Stream["namespace"])
 
 			assert.Equal(t, fixtures.CompleteTargetSendResult.Properties["version"], stream.Stream["version"])


### PR DESCRIPTION
fixes #1349 