### PR TITLE
feat: add TLS authentication to redis

### DIFF
--- a/charts/policy-reporter/README.md
+++ b/charts/policy-reporter/README.md
@@ -358,6 +358,8 @@ Open `http://localhost:8082/` in your browser.
 | redis.username | optional | `""` | Username |
 | redis.password | optional | `""` | Password |
 | redis.certificate | optional | `""` | Path to a server CA certificate |
+| redis.clientCert | optional | `""` | Path to client certificate for mutual TLS authentication |
+| redis.clientKey | optional | `""` | Path to client key for mutual TLS authentication |
 | redis.secretRef | optional | `""` | Secret name to pull username and password from |
 | redis.skipTLS | bool | `false` | Skip TLS verification |
 | database.type | string | `""` | Use an external Database, supported: mysql, postgres, mariadb |

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -887,6 +887,10 @@ redis:
   password: ""
   # -- (optional) Path to a server CA certificate
   certificate: ""
+  # -- (optional) Path to client certificate for mutual TLS authentication
+  clientCert: ""
+  # -- (optional) Path to client key for mutual TLS authentication
+  clientKey: ""
   # -- (optional) Secret name to pull username and password from
   secretRef: ""
   # -- Skip TLS verification

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -113,6 +113,8 @@ type Redis struct {
 	Password    string `mapstructure:"password"`
 	Database    int    `mapstructure:"database"`
 	Certificate string `mapstructure:"certificate"`
+	ClientCert  string `mapstructure:"clientCert"`
+	ClientKey   string `mapstructure:"clientKey"`
 	SecretRef   string `mapstructure:"secretRef"`
 	SkipTLS     bool   `mapstructure:"skipTLS"`
 }

--- a/pkg/config/resolver_test.go
+++ b/pkg/config/resolver_test.go
@@ -409,6 +409,21 @@ func Test_ResolveCache(t *testing.T) {
 
 		assert.NotNil(t, resolver.ResultCache())
 	})
+
+	t.Run("RedisWithClientCertificate", func(t *testing.T) {
+		redisConfig := &config.Config{
+			Redis: config.Redis{
+				Enabled:    true,
+				Address:    "localhost:6380",
+				ClientCert: "/tmp/non-existing-client-cert.pem",
+				ClientKey:  "/tmp/non-existing-client-key.pem",
+			},
+		}
+
+		resolver := config.NewResolver(redisConfig, &rest.Config{})
+
+		assert.NotNil(t, resolver.ResultCache())
+	})
 }
 
 func Test_ResolveReportFilter(t *testing.T) {


### PR DESCRIPTION
This is a follow up of #1368.
Currently the TLS field for redis is only used for the connection itself, but cannot be used to authenticate via TLS to a Redis service.

This PR adds support for TLS client authentication and removes a misleading `ClientAuth` setting for the TLS connection, which refers to a the server part rather than the client.