### PR TITLE
feat(monitoring,mtls): add TLS options to the ServiceMonitor

### DIFF
--- a/charts/policy-reporter/README.md
+++ b/charts/policy-reporter/README.md
@@ -641,6 +641,8 @@ Open `http://localhost:8082/` in your browser.
 | monitoring.serviceMonitor.namespaceSelector | optional | `{}` | NamespaceSelector |
 | monitoring.serviceMonitor.scrapeTimeout | optional | `nil` | ScrapeTimeout |
 | monitoring.serviceMonitor.interval | optional | `nil` | Scrape interval |
+| monitoring.serviceMonitor.secure | bool | `false` | Is TLS required for endpoint |
+| monitoring.serviceMonitor.tlsConfig | object | `{}` | TLS Configuration for endpoint |
 | monitoring.grafana.namespace | string | `nil` | Naamespace for configMap of grafana dashboards |
 | monitoring.grafana.dashboards.enabled | bool | `true` | Enable the deployment of grafana dashboards |
 | monitoring.grafana.dashboards.label | string | `"grafana_dashboard"` | Label to find dashboards using the k8s sidecar |

--- a/charts/policy-reporter/templates/monitoring/servicemonitor.yaml
+++ b/charts/policy-reporter/templates/monitoring/servicemonitor.yaml
@@ -40,6 +40,11 @@ spec:
         name: {{ .Values.basicAuth.secretRef }}
         key: username
     {{- end }}
+    {{- if .Values.monitoring.serviceMonitor.secure }}
+    scheme: https
+    tlsConfig:
+      {{- toYaml .Values.monitoring.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
     honorLabels: {{ .Values.monitoring.serviceMonitor.honorLabels }}
     {{- if .Values.monitoring.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1887,6 +1887,10 @@ monitoring:
     scrapeTimeout:
     # -- (optional) Scrape interval
     interval:
+    # -- Is TLS required for endpoint
+    secure: false
+    # -- TLS Configuration for endpoint
+    tlsConfig: {}
 
   grafana:
     # -- Naamespace for configMap of grafana dashboards


### PR DESCRIPTION
This add TLS options to the Prometheus serviceMonitor, which are needed in an Istio and mTLS enabled cluster.
It's similar to other ServiceMonitors template (e.g. in [kyverno](https://github.com/kyverno/kyverno/blob/main/charts/kyverno/values.yaml#L1319) )
The goal is to be able to generate something like:
```
# Source: policy-reporter/templates/monitoring/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
(...)
  endpoints:
  - port: http
    scheme: https
    tlsConfig:
      caFile: /etc/prom-certs/root-cert.pem
      certFile: /etc/prom-certs/cert-chain.pem
      insecureSkipVerify: true
      keyFile: /etc/prom-certs/key.pem
    honorLabels: false
```

The explanation for this setup can be found in [this post](https://medium.com/@pascal.toepke/how-to-enable-prometheus-scraping-with-istio-mtls-746747864fac)
