### PR TITLE
fix: use dedicated context per event listener

### DIFF
--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -312,7 +312,7 @@ func (r *Resolver) RegisterNewResultsListener() {
 	r.resultListener = listener.NewResultListener(r.SkipExistingOnStartup(), r.ResultCache(), time.Now())
 	r.EventPublisher().RegisterListener(listener.NewResults, r.resultListener.Listen)
 
-	r.EventPublisher().RegisterPostListener(listener.CleanUpListener, listener.NewCleanupListener(context.Background(), targets))
+	r.EventPublisher().RegisterPostListener(listener.CleanUpListener, listener.NewCleanupListener(targets))
 }
 
 // RegisterSendResultListener resolver method
@@ -343,7 +343,7 @@ func (r *Resolver) UnregisterSendResultListener() {
 
 // RegisterStoreListener resolver method
 func (r *Resolver) RegisterStoreListener(ctx context.Context, store report.PolicyReportStore) {
-	r.EventPublisher().RegisterListener(listener.Store, listener.NewStoreListener(ctx, store))
+	r.EventPublisher().RegisterListener(listener.Store, listener.NewStoreListener(store))
 }
 
 // RegisterMetricsListener resolver method

--- a/pkg/kubernetes/debouncer_test.go
+++ b/pkg/kubernetes/debouncer_test.go
@@ -1,6 +1,7 @@
 package kubernetes_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -18,7 +19,7 @@ func Test_Debouncer(t *testing.T) {
 		wg.Add(2)
 
 		publisher := report.NewEventPublisher()
-		publisher.RegisterListener("test", func(event report.LifecycleEvent) {
+		publisher.RegisterListener("test", func(_ context.Context, event report.LifecycleEvent) {
 			counter++
 			wg.Done()
 		})
@@ -55,7 +56,7 @@ func Test_Debouncer(t *testing.T) {
 		wg.Add(2)
 
 		publisher := report.NewEventPublisher()
-		publisher.RegisterListener("test", func(event report.LifecycleEvent) {
+		publisher.RegisterListener("test", func(_ context.Context, event report.LifecycleEvent) {
 			counter++
 			wg.Done()
 		})
@@ -87,7 +88,7 @@ func Test_Debouncer(t *testing.T) {
 		wg.Add(2)
 
 		publisher := report.NewEventPublisher()
-		publisher.RegisterListener("test", func(event report.LifecycleEvent) {
+		publisher.RegisterListener("test", func(_ context.Context, event report.LifecycleEvent) {
 			counter++
 			wg.Done()
 		})

--- a/pkg/kubernetes/openreports/policy_report_client_test.go
+++ b/pkg/kubernetes/openreports/policy_report_client_test.go
@@ -30,7 +30,7 @@ func Test_PolicyReportWatcher(t *testing.T) {
 
 	store := newStore(3)
 	publisher := report.NewEventPublisher()
-	publisher.RegisterListener("test", func(event report.LifecycleEvent) {
+	publisher.RegisterListener("test", func(_ context.Context, event report.LifecycleEvent) {
 		store.Add(event)
 		wg.Done()
 	})
@@ -83,7 +83,7 @@ func Test_ClusterPolicyReportWatcher(t *testing.T) {
 
 	store := newStore(3)
 	publisher := report.NewEventPublisher()
-	publisher.RegisterListener("test", func(event report.LifecycleEvent) {
+	publisher.RegisterListener("test", func(_ context.Context, event report.LifecycleEvent) {
 		store.Add(event)
 		wg.Done()
 	})

--- a/pkg/listener/cleanup.go
+++ b/pkg/listener/cleanup.go
@@ -9,8 +9,8 @@ import (
 
 const CleanUpListener = "cleanup_listener"
 
-func NewCleanupListener(ctx context.Context, targets *target.Collection) report.PolicyReportListener {
-	return func(event report.LifecycleEvent) {
+func NewCleanupListener(targets *target.Collection) report.PolicyReportListener {
+	return func(ctx context.Context, event report.LifecycleEvent) {
 		if event.Type == report.Added {
 			return
 		}

--- a/pkg/listener/cleanup_test.go
+++ b/pkg/listener/cleanup_test.go
@@ -14,8 +14,8 @@ func Test_CleanupListener(t *testing.T) {
 	t.Run("Execute Cleanup Handler", func(t *testing.T) {
 		c := &client{cleanup: true}
 
-		slistener := listener.NewCleanupListener(ctx, target.NewCollection(&target.Target{Client: c}))
-		slistener(report.LifecycleEvent{Type: report.Deleted, PolicyReport: preport1})
+		slistener := listener.NewCleanupListener(target.NewCollection(&target.Target{Client: c}))
+		slistener(ctx, report.LifecycleEvent{Type: report.Deleted, PolicyReport: preport1})
 
 		assert.True(t, c.cleanupCalled, "expected cleanup method was called")
 	})
@@ -25,8 +25,8 @@ func Test_Cleanup_Listener_Skip_Added(t *testing.T) {
 	t.Run("Execute Cleanup Handler", func(t *testing.T) {
 		c := &client{cleanup: true}
 
-		slistener := listener.NewCleanupListener(ctx, target.NewCollection(&target.Target{Client: c}))
-		slistener(report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
+		slistener := listener.NewCleanupListener(target.NewCollection(&target.Target{Client: c}))
+		slistener(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
 
 		assert.False(t, c.cleanupCalled, "expected cleanup execution was skipped")
 	})

--- a/pkg/listener/metrics.go
+++ b/pkg/listener/metrics.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"context"
 	"strings"
 
 	"github.com/kyverno/policy-reporter/pkg/listener/metrics"
@@ -25,11 +26,11 @@ func NewMetricsListener(
 ) report.PolicyReportListener {
 	resultListeners := ResultListeners(filter, reportFilter, mode, fields)
 
-	return func(event report.LifecycleEvent) {
+	return func(ctx context.Context, event report.LifecycleEvent) {
 		if event.PolicyReport.GetNamespace() == "" {
-			resultListeners[1](event)
+			resultListeners[1](ctx, event)
 		} else {
-			resultListeners[0](event)
+			resultListeners[0](ctx, event)
 		}
 	}
 }

--- a/pkg/listener/metrics/cluster_result_detailed.go
+++ b/pkg/listener/metrics/cluster_result_detailed.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -18,7 +20,7 @@ func RegisterDetailedClusterResultGauge(name string) *prometheus.GaugeVec {
 func CreateDetailedClusterResultMetricListener(filter *report.ResultFilter, gauge *prometheus.GaugeVec) report.PolicyReportListener {
 	cache := NewCache(filter, generateClusterResultLabels)
 
-	return func(event report.LifecycleEvent) {
+	return func(ctx context.Context, event report.LifecycleEvent) {
 		newReport := event.PolicyReport
 
 		switch event.Type {

--- a/pkg/listener/metrics/cluster_result_detailed_test.go
+++ b/pkg/listener/metrics/cluster_result_detailed_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
@@ -18,6 +19,8 @@ import (
 )
 
 func Test_DetailedClusterResultMetricGeneration(t *testing.T) {
+	ctx := context.Background()
+
 	gauge := metrics.RegisterDetailedClusterResultGauge("cluster_policy_report_result")
 
 	report1 := &openreports.ReportAdapter{
@@ -46,7 +49,7 @@ func Test_DetailedClusterResultMetricGeneration(t *testing.T) {
 	handler := metrics.CreateDetailedClusterResultMetricListener(filter, gauge)
 
 	t.Run("Added Metric", func(t *testing.T) {
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
@@ -60,8 +63,8 @@ func Test_DetailedClusterResultMetricGeneration(t *testing.T) {
 	})
 
 	t.Run("Modified Metric", func(t *testing.T) {
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
-		handler(report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
@@ -75,9 +78,9 @@ func Test_DetailedClusterResultMetricGeneration(t *testing.T) {
 	})
 
 	t.Run("Deleted Metric", func(t *testing.T) {
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
-		handler(report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
-		handler(report.LifecycleEvent{Type: report.Deleted, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Deleted, PolicyReport: report2})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)

--- a/pkg/listener/metrics/result_custom.go
+++ b/pkg/listener/metrics/result_custom.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	dto "github.com/prometheus/client_model/go"
@@ -28,7 +30,7 @@ func CreateCustomResultMetricsListener(
 ) report.PolicyReportListener {
 	cache := NewCache(filter, labelGenerator)
 
-	return func(event report.LifecycleEvent) {
+	return func(ctx context.Context, event report.LifecycleEvent) {
 		newReport := event.PolicyReport
 
 		switch event.Type {

--- a/pkg/listener/metrics/result_custom_test.go
+++ b/pkg/listener/metrics/result_custom_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
@@ -18,6 +19,8 @@ import (
 )
 
 func Test_CustomResultMetricGeneration(t *testing.T) {
+	ctx := context.Background()
+
 	gauge := metrics.RegisterCustomResultGauge("policy_report_custom_result", []string{"namespace", "policy", "status", "source", "app", "xyz"})
 
 	report1 := &openreports.ReportAdapter{
@@ -50,7 +53,7 @@ func Test_CustomResultMetricGeneration(t *testing.T) {
 
 	t.Run("Added Metric", func(t *testing.T) {
 		handler := metrics.CreateCustomResultMetricsListener(filter, gauge, metrics.CreateLabelGenerator([]string{"namespace", "policy", "status", "source", "label:app", "property:xyz"}, []string{"namespace", "policy", "status", "source", "app", "xyz"}))
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
@@ -67,8 +70,8 @@ func Test_CustomResultMetricGeneration(t *testing.T) {
 		gauge.Reset()
 
 		handler := metrics.CreateCustomResultMetricsListener(filter, gauge, metrics.CreateLabelGenerator([]string{"namespace", "policy", "status", "source", "label:app", "property:xyz"}, []string{"namespace", "policy", "status", "source", "app", "xyz"}))
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
-		handler(report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
@@ -86,9 +89,9 @@ func Test_CustomResultMetricGeneration(t *testing.T) {
 		gauge.Reset()
 
 		handler := metrics.CreateCustomResultMetricsListener(filter, gauge, metrics.CreateLabelGenerator([]string{"namespace", "policy", "status", "source", "label:app", "property:xyz"}, []string{"namespace", "policy", "status", "source", "app", "xyz"}))
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
-		handler(report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
-		handler(report.LifecycleEvent{Type: report.Deleted, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Deleted, PolicyReport: report2})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
@@ -101,9 +104,9 @@ func Test_CustomResultMetricGeneration(t *testing.T) {
 		gauge.Reset()
 
 		handler := metrics.CreateCustomResultMetricsListener(filter, gauge, metrics.CreateLabelGenerator([]string{"namespace", "policy", "status", "source", "label:app", "property:xyz"}, []string{"namespace", "policy", "status", "source", "app", "xyz"}))
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
-		handler(report.LifecycleEvent{Type: report.Deleted, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Deleted, PolicyReport: report1})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)

--- a/pkg/listener/metrics/result_detailed.go
+++ b/pkg/listener/metrics/result_detailed.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -18,7 +20,7 @@ func RegisterDetailedResultGauge(name string) *prometheus.GaugeVec {
 func CreateDetailedResultMetricListener(filter *report.ResultFilter, gauge *prometheus.GaugeVec) report.PolicyReportListener {
 	cache := NewCache(filter, generateResultLabels)
 
-	return func(event report.LifecycleEvent) {
+	return func(ctx context.Context, event report.LifecycleEvent) {
 		newReport := event.PolicyReport
 
 		switch event.Type {

--- a/pkg/listener/metrics/result_detailed_test.go
+++ b/pkg/listener/metrics/result_detailed_test.go
@@ -1,6 +1,7 @@
 package metrics_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
@@ -18,6 +19,8 @@ import (
 )
 
 func Test_DetailedResultMetricGeneration(t *testing.T) {
+	ctx := context.Background()
+
 	gauge := metrics.RegisterDetailedResultGauge("policy_report_result")
 
 	report1 := &openreports.ReportAdapter{
@@ -48,7 +51,7 @@ func Test_DetailedResultMetricGeneration(t *testing.T) {
 	handler := metrics.CreateDetailedResultMetricListener(filter, gauge)
 
 	t.Run("Added Metric", func(t *testing.T) {
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
@@ -62,8 +65,8 @@ func Test_DetailedResultMetricGeneration(t *testing.T) {
 	})
 
 	t.Run("Modified Metric", func(t *testing.T) {
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
-		handler(report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)
@@ -77,9 +80,9 @@ func Test_DetailedResultMetricGeneration(t *testing.T) {
 	})
 
 	t.Run("Deleted Metric", func(t *testing.T) {
-		handler(report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
-		handler(report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
-		handler(report.LifecycleEvent{Type: report.Deleted, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: report1})
+		handler(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: report2})
+		handler(ctx, report.LifecycleEvent{Type: report.Deleted, PolicyReport: report2})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		assert.NoError(t, err)

--- a/pkg/listener/metrics_test.go
+++ b/pkg/listener/metrics_test.go
@@ -19,7 +19,7 @@ func Test_SimpleMetricsListener(t *testing.T) {
 	slistener := listener.NewMetricsListener(&report.ResultFilter{}, &report.ReportFilter{}, metrics.Simple, make([]string, 0))
 
 	t.Run("Add ClusterPolicyReport Metric", func(t *testing.T) {
-		slistener(report.LifecycleEvent{Type: report.Added, PolicyReport: creport})
+		slistener(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: creport})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		if err != nil {
@@ -33,7 +33,7 @@ func Test_SimpleMetricsListener(t *testing.T) {
 		assert.NotNil(t, result, "Metric not found: cluster_policy_report_simple_result")
 	})
 	t.Run("Add PolicyReport Metric", func(t *testing.T) {
-		slistener(report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
+		slistener(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		if err != nil {
@@ -56,7 +56,7 @@ func Test_CustomMetricsListener(t *testing.T) {
 	slistener := listener.NewMetricsListener(&report.ResultFilter{}, &report.ReportFilter{}, metrics.Custom, customFields)
 
 	t.Run("Add ClusterPolicyReport Metric", func(t *testing.T) {
-		slistener(report.LifecycleEvent{Type: report.Added, PolicyReport: creport})
+		slistener(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: creport})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		if err != nil {
@@ -70,7 +70,7 @@ func Test_CustomMetricsListener(t *testing.T) {
 		assert.NotNil(t, result, "Metric not found: cluster_policy_report_custom_result")
 	})
 	t.Run("Add PolicyReport Metric", func(t *testing.T) {
-		slistener(report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
+		slistener(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		if err != nil {
@@ -92,7 +92,7 @@ func Test_MetricsListener(t *testing.T) {
 	slistener := listener.NewMetricsListener(&report.ResultFilter{}, &report.ReportFilter{}, metrics.Detailed, make([]string, 0))
 
 	t.Run("Add ClusterPolicyReport Metric", func(t *testing.T) {
-		slistener(report.LifecycleEvent{Type: report.Added, PolicyReport: creport})
+		slistener(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: creport})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		if err != nil {
@@ -103,7 +103,7 @@ func Test_MetricsListener(t *testing.T) {
 		assert.NotNil(t, result, "Metric not found: cluster_policy_report_result")
 	})
 	t.Run("Add PolicyReport Metric", func(t *testing.T) {
-		slistener(report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
+		slistener(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
 
 		metricFam, err := prometheus.DefaultGatherer.Gather()
 		if err != nil {

--- a/pkg/listener/new_result.go
+++ b/pkg/listener/new_result.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -55,7 +56,7 @@ func (l *ResultListener) Validate(r openreports.ResultAdapter) bool {
 	return true
 }
 
-func (l *ResultListener) Listen(event report.LifecycleEvent) {
+func (l *ResultListener) Listen(_ context.Context, event report.LifecycleEvent) {
 	logger := zap.L().Sugar()
 	logger.Debugf("new event: type %s, report ID %s", event.Type, event.PolicyReport.GetID())
 	if event.Type != report.Added && event.Type != report.Updated {

--- a/pkg/listener/new_result_test.go
+++ b/pkg/listener/new_result_test.go
@@ -25,8 +25,8 @@ func Test_ResultListener(t *testing.T) {
 			called = r
 		})
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
-		slistener.Listen(report.LifecycleEvent{Type: report.Updated, PolicyReport: preport2})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: preport2})
 
 		assert.Equal(t, called.GetID(), fixtures.FailPodResult.GetID(), "Expected Listener to be called with FailPodResult")
 	})
@@ -39,7 +39,7 @@ func Test_ResultListener(t *testing.T) {
 			called = true
 		})
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Deleted, PolicyReport: preport2})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Deleted, PolicyReport: preport2})
 
 		assert.False(t, called, "Expected Listener not be called on Deleted event")
 	})
@@ -52,7 +52,7 @@ func Test_ResultListener(t *testing.T) {
 			called = true
 		})
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Added, PolicyReport: preport2})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: preport2})
 
 		assert.False(t, called, "Expected Listener not be called on Deleted event")
 	})
@@ -65,8 +65,8 @@ func Test_ResultListener(t *testing.T) {
 			called = true
 		})
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Added, PolicyReport: preport2})
-		slistener.Listen(report.LifecycleEvent{Type: report.Updated, PolicyReport: preport2})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: preport2})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: preport2})
 
 		assert.False(t, called, "Expected Listener not be called on cached results")
 	})
@@ -79,7 +79,7 @@ func Test_ResultListener(t *testing.T) {
 			called = true
 		})
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Updated, PolicyReport: preport3})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: preport3})
 
 		assert.False(t, called, "Expected Listener not be called with empty results")
 	})
@@ -89,7 +89,7 @@ func Test_ResultListener(t *testing.T) {
 		or := preport2
 
 		slistener := listener.NewResultListener(true, c, time.Now())
-		slistener.Listen(report.LifecycleEvent{Type: report.Added, PolicyReport: or})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: or})
 
 		assert.Greater(t, len(c.GetResults(or.GetID())), 0, "Expected cached report was found")
 	})
@@ -104,7 +104,7 @@ func Test_ResultListener(t *testing.T) {
 
 		slistener.UnregisterListener()
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Updated, PolicyReport: preport2})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: preport2})
 
 		assert.False(t, called, "Expected Listener not called because it was unregistered")
 	})
@@ -124,7 +124,7 @@ func Test_ResultListener(t *testing.T) {
 			Timestamp: v1.Timestamp{Seconds: time.Now().Add(-24 * time.Hour).Unix()},
 		})
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Updated, PolicyReport: &openreports.ReportAdapter{Report: rep}})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: &openreports.ReportAdapter{Report: rep}})
 
 		assert.False(t, called, "Expected Listener not called because it was unregistered")
 	})
@@ -137,7 +137,7 @@ func Test_ResultListener(t *testing.T) {
 			called = r
 		})
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Added, PolicyReport: scopereport1})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: scopereport1})
 
 		assert.Equal(t, called[0].GetID(), fixtures.FailResult.GetID(), "Expected Listener to be called")
 	})
@@ -152,7 +152,7 @@ func Test_ResultListener(t *testing.T) {
 
 		slistener.UnregisterScopeListener()
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Added, PolicyReport: scopereport1})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: scopereport1})
 
 		assert.Len(t, called, 0, "Expected listener was unregistered")
 	})
@@ -165,7 +165,7 @@ func Test_ResultListener(t *testing.T) {
 			called = r
 		})
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Added, PolicyReport: scopereport1})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: scopereport1})
 
 		assert.Equal(t, called.GetName(), scopereport1.Name, "Expected Listener to be called")
 	})
@@ -180,7 +180,7 @@ func Test_ResultListener(t *testing.T) {
 
 		slistener.UnregisterSyncListener()
 
-		slistener.Listen(report.LifecycleEvent{Type: report.Added, PolicyReport: scopereport1})
+		slistener.Listen(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: scopereport1})
 
 		assert.Nil(t, called, "Expected Listener was unregistered")
 	})

--- a/pkg/listener/store.go
+++ b/pkg/listener/store.go
@@ -2,27 +2,33 @@ package listener
 
 import (
 	"context"
+	"errors"
 
 	"go.uber.org/zap"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/kyverno/policy-reporter/pkg/report"
 )
 
 const Store = "store_listener"
 
-func NewStoreListener(ctx context.Context, store report.PolicyReportStore) report.PolicyReportListener {
-	return func(event report.LifecycleEvent) {
-		if event.Type == report.Deleted {
-			logOnError("remove", event.PolicyReport.GetName(), store.Remove(ctx, event.PolicyReport.GetID()))
-			return
-		}
+func NewStoreListener(store report.PolicyReportStore) report.PolicyReportListener {
+	return func(ctx context.Context, event report.LifecycleEvent) {
+		err := retry.OnError(retry.DefaultRetry, func(err error) bool {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return false
+			}
 
-		if event.Type == report.Updated {
-			logOnError("update", event.PolicyReport.GetName(), store.Update(ctx, event.PolicyReport))
-			return
-		}
+			return true
+		}, func() error {
+			if event.Type == report.Deleted {
+				return store.Remove(ctx, event.PolicyReport.GetID())
+			}
 
-		logOnError("add", event.PolicyReport.GetName(), store.Update(ctx, event.PolicyReport))
+			return store.Update(ctx, event.PolicyReport)
+		})
+
+		logOnError(event.Type.String(), event.PolicyReport.GetName(), err)
 	}
 }
 

--- a/pkg/listener/store_test.go
+++ b/pkg/listener/store_test.go
@@ -14,24 +14,24 @@ func Test_StoreListener(t *testing.T) {
 	store := report.NewPolicyReportStore()
 
 	t.Run("Save New Report", func(t *testing.T) {
-		slistener := listener.NewStoreListener(ctx, store)
-		slistener(report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
+		slistener := listener.NewStoreListener(store)
+		slistener(ctx, report.LifecycleEvent{Type: report.Added, PolicyReport: preport1})
 
 		if _, err := store.Get(ctx, preport1.GetID()); err != nil {
 			t.Error("Expected Report to be stored")
 		}
 	})
 	t.Run("Update Modified Report", func(t *testing.T) {
-		slistener := listener.NewStoreListener(ctx, store)
-		slistener(report.LifecycleEvent{Type: report.Updated, PolicyReport: preport2})
+		slistener := listener.NewStoreListener(store)
+		slistener(ctx, report.LifecycleEvent{Type: report.Updated, PolicyReport: preport2})
 
 		if preport, err := store.Get(ctx, preport2.GetID()); err != nil && len(preport.GetResults()) == 2 {
 			t.Error("Expected Report to be updated")
 		}
 	})
 	t.Run("Remove Deleted Report", func(t *testing.T) {
-		slistener := listener.NewStoreListener(ctx, store)
-		slistener(report.LifecycleEvent{Type: report.Deleted, PolicyReport: preport2})
+		slistener := listener.NewStoreListener(store)
+		slistener(ctx, report.LifecycleEvent{Type: report.Deleted, PolicyReport: preport2})
 
 		if _, err := store.Get(ctx, preport2.GetID()); err == nil {
 			t.Error("Expected Report to be removed")

--- a/pkg/report/client.go
+++ b/pkg/report/client.go
@@ -1,11 +1,13 @@
 package report
 
 import (
+	"context"
+
 	"github.com/kyverno/policy-reporter/pkg/openreports"
 )
 
 // PolicyReportListener is called whenever a new PolicyReport comes in
-type PolicyReportListener = func(LifecycleEvent)
+type PolicyReportListener = func(context.Context, LifecycleEvent)
 
 // PolicyReportResultListener is called whenever a new PolicyResult comes in
 type PolicyReportResultListener = func(openreports.ReportInterface, openreports.ResultAdapter, bool)

--- a/pkg/report/publisher.go
+++ b/pkg/report/publisher.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"context"
 	"sync"
 )
 
@@ -54,7 +55,7 @@ func (p *lifecycleEventPublisher) Publish(event LifecycleEvent) {
 	g.Add(len(p.listeners))
 	for _, listener := range p.listeners {
 		go func(li PolicyReportListener, ev LifecycleEvent) {
-			li(ev)
+			li(context.Background(), ev)
 
 			g.Done()
 		}(listener, event)
@@ -63,14 +64,14 @@ func (p *lifecycleEventPublisher) Publish(event LifecycleEvent) {
 	g.Wait()
 
 	for _, listener := range p.postListeners {
-		listener(event)
+		listener(context.Background(), event)
 	}
 }
 
 func NewEventPublisher() EventPublisher {
 	return &lifecycleEventPublisher{
-		postListeners: make(map[string]func(LifecycleEvent)),
-		listeners:     make(map[string]func(LifecycleEvent)),
+		postListeners: make(map[string]func(context.Context, LifecycleEvent)),
+		listeners:     make(map[string]func(context.Context, LifecycleEvent)),
 		listenerCount: 0,
 	}
 }

--- a/pkg/report/publisher_test.go
+++ b/pkg/report/publisher_test.go
@@ -1,6 +1,7 @@
 package report_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -18,7 +19,7 @@ func Test_PublishLifecycleEvents(t *testing.T) {
 	wg.Add(2)
 
 	publisher := report.NewEventPublisher()
-	publisher.RegisterListener("test", func(le report.LifecycleEvent) {
+	publisher.RegisterListener("test", func(_ context.Context, le report.LifecycleEvent) {
 		event = le
 		wg.Done()
 	})
@@ -55,7 +56,7 @@ func Test_PublishDeleteLifecycleEvents(t *testing.T) {
 	wg.Add(2)
 
 	publisher := report.NewEventPublisher()
-	publisher.RegisterListener("test", func(le report.LifecycleEvent) {
+	publisher.RegisterListener("test", func(_ context.Context, le report.LifecycleEvent) {
 		event = le
 		wg.Done()
 	})
@@ -87,7 +88,7 @@ func Test_PublishDeleteLifecycleEvents(t *testing.T) {
 
 func Test_GetReisteredListeners(t *testing.T) {
 	publisher := report.NewEventPublisher()
-	publisher.RegisterListener("test", func(le report.LifecycleEvent) {})
+	publisher.RegisterListener("test", func(_ context.Context, le report.LifecycleEvent) {})
 
 	if len(publisher.GetListener()) != 1 {
 		t.Error("Expected to get one registered listener back")
@@ -96,7 +97,7 @@ func Test_GetReisteredListeners(t *testing.T) {
 
 func Test_UnreisteredListeners(t *testing.T) {
 	publisher := report.NewEventPublisher()
-	publisher.RegisterListener("test", func(le report.LifecycleEvent) {})
+	publisher.RegisterListener("test", func(_ context.Context, le report.LifecycleEvent) {})
 	publisher.UnregisterListener("test")
 
 	if len(publisher.GetListener()) != 0 {


### PR DESCRIPTION
each report event listener now gets its own context instead of using a global single one. This avoids general database operations stop working when a single one gets cancelled.

Also adding a retry to the store listener