### PR TITLE
feat(chart): complete httproute backendRefs to avoid differences

### DIFF
--- a/charts/policy-reporter/templates/httproute.yaml
+++ b/charts/policy-reporter/templates/httproute.yaml
@@ -42,7 +42,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       backendRefs:
-        - name: {{ $fullName }}
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
           port: {{ $svcPort }}
           weight: 1
     {{- end }}

--- a/charts/policy-reporter/templates/plugins/kyverno/httproute.yaml
+++ b/charts/policy-reporter/templates/plugins/kyverno/httproute.yaml
@@ -36,7 +36,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       backendRefs:
-        - name: {{ $fullName }}
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
           port: {{ $svcPort }}
           weight: 1
     {{- end }}

--- a/charts/policy-reporter/templates/ui/httproute.yaml
+++ b/charts/policy-reporter/templates/ui/httproute.yaml
@@ -36,7 +36,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       backendRefs:
-        - name: {{ $fullName }}
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
           port: {{ $svcPort }}
           weight: 1
     {{- end }}


### PR DESCRIPTION
Hi,

When using `HTTProute` with Gitops tools like ArgoCD, differences remains because of missing (implicit) settings.

This PR will fix that.

<img width="427" height="175" alt="image" src="https://github.com/user-attachments/assets/3783efb9-b862-418c-bc45-2fefc3414a10" />
