### PR TITLE
feat(charts): added serviceMonitor.enabled flag

### DIFF
--- a/charts/policy-reporter/templates/monitoring/servicemonitor.yaml
+++ b/charts/policy-reporter/templates/monitoring/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.monitoring.enabled }}
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1870,6 +1870,7 @@ monitoring:
   annotations: {}
 
   serviceMonitor:
+    enabled: true
     # -- HonorLabels chooses the metrics labels on collisions with target labels
     honorLabels: false
     # -- Allow to override the namespace for serviceMonitor


### PR DESCRIPTION
For clusters without Prometheus Operator, it would be very helpful to have a toggle to disable the creation of the `ServiceMonitor` manifest while still being able to use `.Values.monitoring` to render the Grafana dashboards.

Currently, enabling `.Values.monitoring` also deploys a `ServiceMonitor`, which breaks deployments in clusters without the Prometheus Operator CRDs installed. This change introduces a dedicated toggle so users can still enable monitoring-related resources like Grafana dashboard ConfigMaps without requiring the `ServiceMonitor` CRD.

