### PR TITLE
fix(api): fall back to embedded HTML report templates

### DIFF
--- a/pkg/email/summary/reporter.go
+++ b/pkg/email/summary/reporter.go
@@ -2,10 +2,13 @@ package summary
 
 import (
 	"html/template"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/kyverno/policy-reporter/pkg/email"
+	"github.com/kyverno/policy-reporter/templates"
 )
 
 type Reporter struct {
@@ -17,7 +20,7 @@ type Reporter struct {
 func (o *Reporter) Report(sources []Source, format string) (email.Report, error) {
 	b := new(strings.Builder)
 
-	templ, err := template.ParseFiles(o.templateDir + "/summary.html")
+	templ, err := parseTemplate(o.templateDir, "summary.html")
 	if err != nil {
 		return email.Report{}, err
 	}
@@ -46,6 +49,21 @@ func (o *Reporter) Report(sources []Source, format string) (email.Report, error)
 		Message:     b.String(),
 		Format:      format,
 	}, nil
+}
+
+// parseTemplate loads name preferring the on-disk templateDir when the file
+// exists there and otherwise falling back to the embedded copy that ships with
+// the binary, keeping the --template-dir override working while making
+// rendering resilient to a missing templates directory.
+func parseTemplate(templateDir, name string) (*template.Template, error) {
+	if templateDir != "" {
+		path := filepath.Join(templateDir, name)
+		if _, err := os.Stat(path); err == nil {
+			return template.ParseFiles(path)
+		}
+	}
+
+	return template.ParseFS(templates.FS, name)
 }
 
 func NewReporter(templateDir, clusterName string, titlePrefix string) *Reporter {

--- a/pkg/email/violations/reporter.go
+++ b/pkg/email/violations/reporter.go
@@ -2,11 +2,14 @@ package violations
 
 import (
 	"html/template"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/kyverno/policy-reporter/pkg/email"
 	"github.com/kyverno/policy-reporter/pkg/helper"
+	"github.com/kyverno/policy-reporter/templates"
 )
 
 type Reporter struct {
@@ -29,7 +32,7 @@ func (o *Reporter) Report(sources []Source, format string) (email.Report, error)
 		},
 	})
 
-	templ, err := vioTempl.ParseFiles(o.templateDir + "/violations.html")
+	templ, err := parseTemplate(vioTempl, o.templateDir, "violations.html")
 	if err != nil {
 		return email.Report{}, err
 	}
@@ -60,6 +63,21 @@ func (o *Reporter) Report(sources []Source, format string) (email.Report, error)
 		Message:     b.String(),
 		Format:      format,
 	}, nil
+}
+
+// parseTemplate loads name into templ, preferring the on-disk templateDir when
+// the file exists there and otherwise falling back to the embedded copy that
+// ships with the binary. This keeps the --template-dir override working while
+// making the report endpoint resilient to a missing templates directory.
+func parseTemplate(templ *template.Template, templateDir, name string) (*template.Template, error) {
+	if templateDir != "" {
+		path := filepath.Join(templateDir, name)
+		if _, err := os.Stat(path); err == nil {
+			return templ.ParseFiles(path)
+		}
+	}
+
+	return templ.ParseFS(templates.FS, name)
 }
 
 func NewReporter(templateDir string, clusterName string, titlePrefix string) *Reporter {

--- a/pkg/email/violations/reporter_test.go
+++ b/pkg/email/violations/reporter_test.go
@@ -60,3 +60,34 @@ func Test_CreateReport(t *testing.T) {
 		t.Fatal("expected format to be set")
 	}
 }
+
+// Test_CreateReport_EmbeddedFallback covers the case from issue #1466 where the
+// templates directory is not present on disk. The reporter must fall back to the
+// embedded template and still render instead of failing with a
+// "no such file or directory" error (which surfaced as a failed report request).
+func Test_CreateReport_EmbeddedFallback(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	client, pClient, cClient := NewFakeClient()
+
+	_, _ = pClient.Create(ctx, fixtures.DefaultPolicyReport.Report, v1.CreateOptions{})
+	_, _ = cClient.Create(ctx, fixtures.ClusterPolicyReport.ClusterReport, v1.CreateOptions{})
+
+	generator := violations.NewGenerator(client.OpenreportsV1alpha1(), nil, filter, true)
+	data, err := generator.GenerateData(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	for _, dir := range []string{"", "/does/not/exist"} {
+		reporter := violations.NewReporter(dir, "Cluster", "Report")
+		report, err := reporter.Report(data, "html")
+		if err != nil {
+			t.Fatalf("template dir %q: unexpected error: %s", dir, err)
+		}
+		if report.Message == "" {
+			t.Fatalf("template dir %q: expected a rendered report message", dir)
+		}
+	}
+}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,0 +1,11 @@
+// Package templates exposes the bundled HTML report templates through an
+// embedded filesystem so the binary can always render reports even when no
+// template directory is present on disk (for example in a custom image where
+// /app/templates is missing). The on-disk --template-dir override still takes
+// precedence when the requested file exists there.
+package templates
+
+import "embed"
+
+//go:embed *.html
+var FS embed.FS


### PR DESCRIPTION
Fixes #1466

## Problem

`GET /v1/html-report/violations` loads its HTML template from the templates directory at request time:

```go
templ, err := vioTempl.ParseFiles(o.templateDir + "/violations.html")
```

`templateDir` defaults to `./templates` (resolved to `/app/templates` in the official image and via the Helm chart `--template-dir=/app/templates`). When that directory is not present on disk - for example a custom image where `/app/templates` was not copied, or a deployment that overrides the working directory or template path - `ParseFiles` fails with `open .../violations.html: no such file or directory` and the report request errors out. That is exactly the "file or directory cannot be found" log and failed request reported in the issue.

The summary email reporter (`pkg/email/summary/reporter.go`) has the same on-disk dependency.

## Fix

Embed the bundled templates into the binary and load them disk-first with an embedded fallback:

- New `templates` package with `//go:embed *.html` over the existing `templates/violations.html` and `templates/summary.html` (no template content moved).
- Both reporters now resolve a template via a small helper: if `--template-dir` is set and the file exists there, it is used (existing override behaviour is preserved); otherwise the embedded copy is used.

This makes the endpoint resilient to a missing templates directory while keeping the `--template-dir` override intact.

## Before / after

Before (no templates dir on disk): the reporter returns `open /violations.html: no such file or directory` and the request fails.

After: the reporter renders from the embedded template and returns the report. A regression test exercises the empty and non-existent template-directory cases:

```
Test_CreateReport_EmbeddedFallback   PASS
Test_CreateReport (on-disk path)     PASS
HTMLViolationsReport (handler -> 200) PASS
```

`go build ./...` and `go test ./pkg/...` are green.
