### PR TITLE
Enhance email client with Microsoft Graph API support and refactor

### DIFF
--- a/charts/policy-reporter/README.md
+++ b/charts/policy-reporter/README.md
@@ -127,6 +127,17 @@ Open `http://localhost:8082/` in your browser.
 | emailReports.smtp.encryption | string | `""` | SMTP Encryption Default is none, supports ssl/tls and starttls |
 | emailReports.smtp.skipTLS | bool | `false` | Skip SMTP TLS verification |
 | emailReports.smtp.certificate | string | `""` | SMTP Server Certificate file path |
+| emailReports.graphAPI.enabled | bool | `false` | Enable Microsoft Graph API for E-Mail reports, takes precedence over SMTP |
+| emailReports.graphAPI.tenant | string | `""` | Microsoft Graph API Tenant ID |
+| emailReports.graphAPI.clientID | string | `""` | Microsoft Graph API Client ID |
+| emailReports.graphAPI.clientSecret | string | `""` | Microsoft Graph API Client Secret |
+| emailReports.graphAPI.secretRef | string | `""` | (optional) Name of an existing Secret with a `clientSecret` key, used instead of `clientSecret` |
+| emailReports.graphAPI.userID | string | `""` | Microsoft Graph API User ID (Sender) |
+| emailReports.graphAPI.cc | list | `[]` | Microsoft Graph API CC Recipients |
+| emailReports.graphAPI.bcc | list | `[]` | Microsoft Graph API BCC Recipients |
+| emailReports.graphAPI.disableSaveToSentItems | bool | `false` | Disable saving sent messages to the Sent Items folder |
+| emailReports.graphAPI.azureADEndpoint | string | `"https://login.microsoftonline.com"` | Microsoft Graph API Azure AD Endpoint override |
+| emailReports.graphAPI.graphEndpoint | string | `"https://graph.microsoft.com"` | Microsoft Graph API endpoint override |
 | emailReports.summary.enabled | bool | `false` | Enable Summary E-Mail reports |
 | emailReports.summary.schedule | string | `"0 8 * * *"` | CronJob schedule |
 | emailReports.summary.activeDeadlineSeconds | int | `300` | CronJob activeDeadlineSeconds |

--- a/charts/policy-reporter/configs/email-reports.tmpl
+++ b/charts/policy-reporter/configs/email-reports.tmpl
@@ -5,6 +5,10 @@ emailReports:
   smtp:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.emailReports.graphAPI }}
+  graphAPI:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 
   summary:
     {{- with .Values.emailReports.summary.to }}

--- a/charts/policy-reporter/templates/cronjob-summary-report.yaml
+++ b/charts/policy-reporter/templates/cronjob-summary-report.yaml
@@ -72,8 +72,12 @@ spec:
               {{- with .Values.extraVolumes.volumeMounts }}
               {{ toYaml . | nindent 14 | trim }}
               {{- end }}
-              {{- if .Values.emailReports.smtp.secret }}
               env:
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              {{- if .Values.emailReports.smtp.secret }}
               - name: EMAIL_REPORTS_SMTP_HOST
                 valueFrom:
                   secretKeyRef:

--- a/charts/policy-reporter/templates/cronjob-violations-report.yaml
+++ b/charts/policy-reporter/templates/cronjob-violations-report.yaml
@@ -72,8 +72,12 @@ spec:
               {{- with .Values.extraVolumes.volumeMounts }}
               {{ toYaml . | nindent 14 | trim }}
               {{- end }}
-              {{- if .Values.emailReports.smtp.secret }}
               env:
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              {{- if .Values.emailReports.smtp.secret }}
               - name: EMAIL_REPORTS_SMTP_HOST
                 valueFrom:
                   secretKeyRef:

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -283,6 +283,29 @@ emailReports:
     skipTLS: false
     # -- SMTP Server Certificate file path
     certificate: ""
+  graphAPI:
+    # -- Enable Microsoft Graph API for E-Mail reports, takes precedence over SMTP
+    enabled: false
+    # -- Microsoft Graph API Tenant ID
+    tenant: ""
+    # -- Microsoft Graph API Client ID
+    clientID: ""
+    # -- Microsoft Graph API Client Secret
+    clientSecret: ""
+    # -- (optional) Name of an existing Secret with a `clientSecret` key, used instead of `clientSecret`
+    secretRef: ""
+    # -- Microsoft Graph API User ID (Sender)
+    userID: ""
+    # -- Microsoft Graph API CC Recipients
+    cc: []
+    # -- Microsoft Graph API BCC Recipients
+    bcc: []
+    # -- Disable saving sent messages to the Sent Items folder
+    disableSaveToSentItems: false
+    # -- Microsoft Graph API Azure AD Endpoint override
+    azureADEndpoint: "https://login.microsoftonline.com"
+    # -- Microsoft Graph API endpoint override
+    graphEndpoint: "https://graph.microsoft.com"
 
   summary:
     # -- Enable Summary E-Mail reports

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,21 @@ type SMTP struct {
 	Certificate string `mapstructure:"certificate"`
 }
 
+// GraphAPI configuration
+type GraphAPI struct {
+	Enabled                bool     `mapstructure:"enabled"`
+	Tenant                 string   `mapstructure:"tenant"`
+	ClientID               string   `mapstructure:"clientID"`
+	ClientSecret           string   `mapstructure:"clientSecret"`
+	SecretRef              string   `mapstructure:"secretRef"`
+	UserID                 string   `mapstructure:"userID"`
+	CC                     []string `mapstructure:"cc"`
+	BCC                    []string `mapstructure:"bcc"`
+	DisableSaveToSentItems bool     `mapstructure:"disableSaveToSentItems"`
+	AzureADEndpoint        string   `mapstructure:"azureADEndpoint"`
+	GraphEndpoint          string   `mapstructure:"graphEndpoint"`
+}
+
 // EmailReport configuration
 type EmailReport struct {
 	To       []string          `mapstructure:"to"`
@@ -58,6 +73,7 @@ type Templates struct {
 // EmailReports configuration
 type EmailReports struct {
 	SMTP        SMTP        `mapstructure:"smtp"`
+	GraphAPI    GraphAPI    `mapstructure:"graphAPI"`
 	Summary     EmailReport `mapstructure:"summary"`
 	Violations  EmailReport `mapstructure:"violations"`
 	ClusterName string      `mapstructure:"clusterName"`

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -110,6 +110,13 @@ func Load(cmd *cobra.Command) (*Config, error) {
 	_ = v.BindEnv("emailReports.smtp.host", "EMAIL_REPORTS_SMTP_HOST")
 	_ = v.BindEnv("emailReports.smtp.port", "EMAIL_REPORTS_SMTP_PORT")
 	_ = v.BindEnv("emailReports.smtp.from", "EMAIL_REPORTS_SMTP_FROM")
+	// bind graphAPI config from environment vars, if existing
+	_ = v.BindEnv("emailReports.graphAPI.clientSecret", "EMAIL_REPORTS_GRAPHAPI_CLIENTSECRET")
+	_ = v.BindEnv("emailReports.graphAPI.tenant", "EMAIL_REPORTS_GRAPHAPI_TENANT")
+	_ = v.BindEnv("emailReports.graphAPI.clientID", "EMAIL_REPORTS_GRAPHAPI_CLIENTID")
+	_ = v.BindEnv("emailReports.graphAPI.userID", "EMAIL_REPORTS_GRAPHAPI_USERID")
+	_ = v.BindEnv("emailReports.graphAPI.azureADEndpoint", "EMAIL_REPORTS_GRAPHAPI_AZUREADENDPOINT")
+	_ = v.BindEnv("emailReports.graphAPI.graphEndpoint", "EMAIL_REPORTS_GRAPHAPI_GRAPHENDPOINT")
 	// bind slack webhook from environment vars, if existing
 	_ = v.BindEnv("slack.webhook", "SLACK_WEBHOOK")
 	// bind ui host from environment vars, if existing

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -58,6 +58,7 @@ type Resolver struct {
 	config             *Config
 	k8sConfig          *rest.Config
 	clientset          *k8s.Clientset
+	k8sClient          k8s.Interface
 	publisher          report.EventPublisher
 	policyStore        *database.Store
 	database           *bun.DB
@@ -382,9 +383,21 @@ func (r *Resolver) Clientset() (*k8s.Clientset, error) {
 	return r.clientset, nil
 }
 
+func (r *Resolver) k8s() (k8s.Interface, error) {
+	if r.k8sClient != nil {
+		return r.k8sClient, nil
+	}
+	clientset, err := r.Clientset()
+	if err != nil {
+		return nil, err
+	}
+	r.k8sClient = clientset
+	return r.k8sClient, nil
+}
+
 // SecretClient resolver method
 func (r *Resolver) SecretClient() secrets.Client {
-	clientset, err := r.Clientset()
+	clientset, err := r.k8s()
 	if err != nil {
 		return nil
 	}
@@ -654,8 +667,52 @@ func (r *Resolver) SMTPServer() *mail.SMTPServer {
 	return server
 }
 
-func (r *Resolver) EmailClient() *email.Client {
+func (r *Resolver) EmailClient() email.Sender {
+	graphAPI := r.config.EmailReports.GraphAPI
+	if graphAPI.Enabled {
+		return email.NewGraphAPIClient(
+			graphAPI.Tenant,
+			graphAPI.ClientID,
+			r.graphAPIClientSecret(graphAPI),
+			graphAPI.UserID,
+			email.GraphAPIClientOptions{
+				CC:                     graphAPI.CC,
+				BCC:                    graphAPI.BCC,
+				DisableSaveToSentItems: graphAPI.DisableSaveToSentItems,
+				AzureADEndpoint:        graphAPI.AzureADEndpoint,
+				GraphEndpoint:          graphAPI.GraphEndpoint,
+			},
+		)
+	}
+
 	return email.NewClient(r.config.EmailReports.SMTP.From, r.SMTPServer())
+}
+
+// graphAPIClientSecret resolves the Graph API client secret from the referenced
+// secret's "clientSecret" key, falling back to the inline configured value.
+func (r *Resolver) graphAPIClientSecret(graphAPI GraphAPI) string {
+	if graphAPI.SecretRef == "" {
+		return graphAPI.ClientSecret
+	}
+
+	client := r.SecretClient()
+	if client == nil {
+		zap.L().Error("failed to create secret client for graph api client secret", zap.String("secretRef", graphAPI.SecretRef))
+		return graphAPI.ClientSecret
+	}
+
+	values, err := client.Get(context.Background(), graphAPI.SecretRef)
+	if err != nil {
+		zap.L().Error("failed to load graph api client secret", zap.Error(err), zap.String("secretRef", graphAPI.SecretRef))
+		return graphAPI.ClientSecret
+	}
+
+	if values.ClientSecret == "" {
+		zap.L().Error("clientSecret key not found in graph api secret", zap.String("secretRef", graphAPI.SecretRef))
+		return graphAPI.ClientSecret
+	}
+
+	return values.ClientSecret
 }
 
 func (r *Resolver) TargetConfigClient() (*targetconfig.Client, error) {

--- a/pkg/config/resolver_internal_test.go
+++ b/pkg/config/resolver_internal_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	"github.com/kyverno/policy-reporter/pkg/email"
+)
+
+func TestEmailClient_GraphAPI(t *testing.T) {
+	graphClientType := email.NewGraphAPIClient("", "", "", "", email.GraphAPIClientOptions{})
+
+	t.Run("returns graph api client when enabled", func(t *testing.T) {
+		cfg := &Config{
+			EmailReports: EmailReports{
+				GraphAPI: GraphAPI{
+					Enabled:      true,
+					Tenant:       "tenant",
+					ClientID:     "client",
+					ClientSecret: "secret",
+					UserID:       "user",
+				},
+			},
+		}
+		resolver := NewResolver(cfg, &rest.Config{})
+
+		assert.IsType(t, graphClientType, resolver.EmailClient())
+	})
+
+	t.Run("returns smtp client when graph api is disabled", func(t *testing.T) {
+		cfg := &Config{
+			EmailReports: EmailReports{
+				GraphAPI: GraphAPI{Enabled: false},
+			},
+		}
+		resolver := NewResolver(cfg, &rest.Config{})
+
+		assert.IsType(t, &email.Client{}, resolver.EmailClient())
+	})
+
+	t.Run("custom endpoints", func(t *testing.T) {
+		cfg := &Config{
+			EmailReports: EmailReports{
+				GraphAPI: GraphAPI{
+					Enabled:         true,
+					Tenant:          "tenant",
+					ClientID:        "client-alt",
+					ClientSecret:    "secret",
+					UserID:          "user-alt",
+					AzureADEndpoint: "https://login.microsoftonline.de",
+					GraphEndpoint:   "https://graph.microsoft.de",
+				},
+			},
+		}
+		resolver := NewResolver(cfg, &rest.Config{})
+
+		assert.IsType(t, graphClientType, resolver.EmailClient())
+	})
+}
+
+func TestGraphAPIClientSecret(t *testing.T) {
+	t.Run("resolves clientSecret from referenced secret", func(t *testing.T) {
+		graphAPI := GraphAPI{
+			ClientSecret: "inline-secret",
+			SecretRef:    "graph-secret",
+		}
+
+		resolver := NewResolver(&Config{Namespace: "default"}, &rest.Config{})
+		resolver.k8sClient = fake.NewClientset(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "graph-secret",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"clientSecret": []byte("resolved-secret-value"),
+			},
+		})
+
+		assert.Equal(t, "resolved-secret-value", resolver.graphAPIClientSecret(graphAPI))
+	})
+
+	t.Run("falls back to inline clientSecret without secretRef", func(t *testing.T) {
+		graphAPI := GraphAPI{ClientSecret: "inline-secret"}
+
+		resolver := NewResolver(&Config{Namespace: "default"}, &rest.Config{})
+
+		assert.Equal(t, "inline-secret", resolver.graphAPIClientSecret(graphAPI))
+	})
+
+	t.Run("falls back to inline clientSecret when secret is missing", func(t *testing.T) {
+		graphAPI := GraphAPI{
+			ClientSecret: "inline-secret",
+			SecretRef:    "missing-secret",
+		}
+
+		resolver := NewResolver(&Config{Namespace: "default"}, &rest.Config{})
+		resolver.k8sClient = fake.NewClientset()
+
+		assert.Equal(t, "inline-secret", resolver.graphAPIClientSecret(graphAPI))
+	})
+
+	t.Run("falls back to inline clientSecret when key is missing", func(t *testing.T) {
+		graphAPI := GraphAPI{
+			ClientSecret: "inline-secret",
+			SecretRef:    "graph-secret",
+		}
+
+		resolver := NewResolver(&Config{Namespace: "default"}, &rest.Config{})
+		resolver.k8sClient = fake.NewClientset(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "graph-secret",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"other": []byte("value"),
+			},
+		})
+
+		assert.Equal(t, "inline-secret", resolver.graphAPIClientSecret(graphAPI))
+	})
+}

--- a/pkg/config/resolver_test.go
+++ b/pkg/config/resolver_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/crd/api/targetconfig"
 	"github.com/kyverno/policy-reporter/pkg/crd/api/targetconfig/v1alpha1"
 	"github.com/kyverno/policy-reporter/pkg/database"
+	"github.com/kyverno/policy-reporter/pkg/email"
 	"github.com/kyverno/policy-reporter/pkg/report"
 	"github.com/kyverno/policy-reporter/pkg/target"
 )
@@ -570,6 +571,28 @@ func Test_SMTP(t *testing.T) {
 		resolver := config.NewResolver(testConfig, &rest.Config{})
 
 		assert.NotNil(t, resolver.EmailClient())
+	})
+}
+
+func Test_GraphAPI(t *testing.T) {
+	t.Run("GraphAPI EmailClient", func(t *testing.T) {
+		graphConfig := &config.Config{
+			EmailReports: config.EmailReports{
+				GraphAPI: config.GraphAPI{
+					Enabled:                true,
+					Tenant:                 "tenant",
+					ClientID:               "client",
+					ClientSecret:           "secret",
+					UserID:                 "user",
+					CC:                     []string{"cc@example.com"},
+					BCC:                    []string{"bcc@example.com"},
+					DisableSaveToSentItems: false,
+				},
+			},
+		}
+		resolver := config.NewResolver(graphConfig, &rest.Config{})
+
+		assert.IsType(t, email.NewGraphAPIClient("", "", "", "", email.GraphAPIClientOptions{}), resolver.EmailClient())
 	})
 }
 

--- a/pkg/email/client.go
+++ b/pkg/email/client.go
@@ -18,6 +18,12 @@ func EncryptionFromString(enc string) mail.Encryption {
 	}
 }
 
+// Sender is the interface for sending email reports.
+// Implemented by Client (SMTP) and graphAPIClient (Microsoft Graph API).
+type Sender interface {
+	Send(report Report, to []string) error
+}
+
 type Client struct {
 	server *mail.SMTPServer
 	from   string

--- a/pkg/email/graphapi.go
+++ b/pkg/email/graphapi.go
@@ -1,0 +1,155 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+type emailAddress struct {
+	Address string `json:"address"`
+	// Name is the optional display name shown in email clients.
+	Name string `json:"name,omitempty"`
+}
+
+type recipient struct {
+	EmailAddress emailAddress `json:"emailAddress"`
+}
+
+type graphMessage struct {
+	Message struct {
+		Subject string `json:"subject"`
+		Body    struct {
+			ContentType string `json:"contentType"`
+			Content     string `json:"content"`
+		} `json:"body"`
+		ToRecipients  []recipient `json:"toRecipients"`
+		CcRecipients  []recipient `json:"ccRecipients,omitempty"`
+		BccRecipients []recipient `json:"bccRecipients,omitempty"`
+	} `json:"message"`
+	// SaveToSentItems controls whether the sent message is saved in the Sent Items folder.
+	// Always explicitly sent to avoid relying on server-side defaults.
+	SaveToSentItems bool `json:"saveToSentItems"`
+}
+
+type graphAPIClient struct {
+	// httpClient handles OAuth2 tokens transparently, fetching and refreshing
+	// them as needed via the client credentials flow.
+	httpClient             *http.Client
+	userID                 string
+	cc                     []string
+	bcc                    []string
+	disableSaveToSentItems bool
+	graphEndpoint          string
+}
+
+// makeRecipients converts a list of email address strings into Graph API recipient objects.
+// Returns nil (not an empty slice) when addrs is empty so that fields tagged with
+// omitempty are correctly omitted from the JSON payload.
+func makeRecipients(addrs []string) []recipient {
+	if len(addrs) == 0 {
+		return nil
+	}
+	rs := make([]recipient, 0, len(addrs))
+	for _, addr := range addrs {
+		r := recipient{}
+		r.EmailAddress.Address = addr
+		rs = append(rs, r)
+	}
+	return rs
+}
+
+func (c *graphAPIClient) Send(report Report, to []string) error {
+	msg := graphMessage{}
+	msg.Message.Subject = report.Title
+	if strings.ToLower(report.Format) == "html" || report.Format == "" {
+		msg.Message.Body.ContentType = "HTML"
+	} else {
+		msg.Message.Body.ContentType = "Text"
+	}
+	msg.Message.Body.Content = report.Message
+	msg.Message.ToRecipients = makeRecipients(to)
+	msg.Message.CcRecipients = makeRecipients(c.cc)
+	msg.Message.BccRecipients = makeRecipients(c.bcc)
+	msg.SaveToSentItems = !c.disableSaveToSentItems
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/v1.0/users/%s/sendMail", c.graphEndpoint, c.userID)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to send email via Graph API: %s – %s", resp.Status, string(respBody))
+	}
+
+	return nil
+}
+
+// GraphAPIClientOptions holds optional settings for the Microsoft Graph API email sender.
+type GraphAPIClientOptions struct {
+	// CC is a list of email addresses to carbon-copy on every sent message.
+	CC []string
+	// BCC is a list of email addresses to blind-carbon-copy on every sent message.
+	BCC []string
+	// DisableSaveToSentItems controls whether sent messages are saved in the Sent Items folder.
+	// Defaults to false (which means messages ARE saved). Set to true to suppress saving.
+	DisableSaveToSentItems bool
+	// AzureADEndpoint overrides the default Azure Active Directory / Entra ID endpoint.
+	// Defaults to "https://login.microsoftonline.com" if not set.
+	AzureADEndpoint string
+	// GraphEndpoint overrides the default Microsoft Graph API endpoint.
+	// Defaults to "https://graph.microsoft.com" if not set.
+	GraphEndpoint string
+}
+
+// NewGraphAPIClient creates a Sender backed by the Microsoft Graph API.
+// OAuth2 tokens are obtained via the client credentials flow on first use and
+// refreshed automatically when they expire.
+// Pass GraphAPIClientOptions to configure CC, BCC, and Sent Items behaviour.
+func NewGraphAPIClient(tenant, clientID, clientSecret, userID string, opts GraphAPIClientOptions) Sender {
+	azureADEndpoint := strings.TrimSuffix(opts.AzureADEndpoint, "/")
+	if azureADEndpoint == "" {
+		azureADEndpoint = "https://login.microsoftonline.com"
+	}
+	graphEndpoint := strings.TrimSuffix(opts.GraphEndpoint, "/")
+	if graphEndpoint == "" {
+		graphEndpoint = "https://graph.microsoft.com"
+	}
+
+	config := &clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     fmt.Sprintf("%s/%s/oauth2/v2.0/token", azureADEndpoint, tenant),
+		Scopes:       []string{fmt.Sprintf("%s/.default", graphEndpoint)},
+	}
+
+	return &graphAPIClient{
+		httpClient:             config.Client(context.Background()),
+		userID:                 userID,
+		cc:                     opts.CC,
+		bcc:                    opts.BCC,
+		disableSaveToSentItems: opts.DisableSaveToSentItems,
+		graphEndpoint:          graphEndpoint,
+	}
+}

--- a/pkg/email/graphapi.go
+++ b/pkg/email/graphapi.go
@@ -8,9 +8,15 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
+
+// requestTimeout bounds each HTTP request (token fetch and sendMail),
+// including connection setup, TLS handshake and reading the response body.
+const requestTimeout = 30 * time.Second
 
 type emailAddress struct {
 	Address string `json:"address"`
@@ -144,8 +150,14 @@ func NewGraphAPIClient(tenant, clientID, clientSecret, userID string, opts Graph
 		Scopes:       []string{fmt.Sprintf("%s/.default", graphEndpoint)},
 	}
 
+	// Token requests are made through the client stored in the oauth2.HTTPClient
+	// context value, so give it a timeout too instead of http.DefaultClient's none.
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Timeout: requestTimeout})
+	httpClient := config.Client(ctx)
+	httpClient.Timeout = requestTimeout
+
 	return &graphAPIClient{
-		httpClient:             config.Client(context.Background()),
+		httpClient:             httpClient,
 		userID:                 userID,
 		cc:                     opts.CC,
 		bcc:                    opts.BCC,

--- a/pkg/email/graphapi_test.go
+++ b/pkg/email/graphapi_test.go
@@ -1,0 +1,120 @@
+package email_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kyverno/policy-reporter/pkg/email"
+)
+
+type sendMailPayload struct {
+	Message struct {
+		Subject string `json:"subject"`
+		Body    struct {
+			ContentType string `json:"contentType"`
+			Content     string `json:"content"`
+		} `json:"body"`
+		ToRecipients []struct {
+			EmailAddress struct {
+				Address string `json:"address"`
+			} `json:"emailAddress"`
+		} `json:"toRecipients"`
+		CcRecipients  []json.RawMessage `json:"ccRecipients"`
+		BccRecipients []json.RawMessage `json:"bccRecipients"`
+	} `json:"message"`
+	SaveToSentItems bool `json:"saveToSentItems"`
+}
+
+func newGraphServer(t *testing.T, sendMailStatus int, sendMailBody string) (*httptest.Server, *map[string]any) {
+	t.Helper()
+
+	captured := map[string]any{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tenant/oauth2/v2.0/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"test-token","token_type":"Bearer","expires_in":3600}`))
+	})
+	mux.HandleFunc("/v1.0/users/user/sendMail", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured["authorization"] = r.Header.Get("Authorization")
+		captured["contentType"] = r.Header.Get("Content-Type")
+		captured["body"] = body
+		w.WriteHeader(sendMailStatus)
+		_, _ = w.Write([]byte(sendMailBody))
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return server, &captured
+}
+
+func TestGraphAPIClient_Send(t *testing.T) {
+	t.Run("sends expected payload", func(t *testing.T) {
+		server, captured := newGraphServer(t, http.StatusAccepted, "")
+
+		client := email.NewGraphAPIClient("tenant", "client", "secret", "user", email.GraphAPIClientOptions{
+			CC:                     []string{"cc@example.com"},
+			DisableSaveToSentItems: true,
+			AzureADEndpoint:        server.URL,
+			GraphEndpoint:          server.URL,
+		})
+
+		err := client.Send(email.Report{
+			Title:   "Report Title",
+			Message: "<h1>Summary</h1>",
+			Format:  "html",
+		}, []string{"to@example.com"})
+		assert.NoError(t, err)
+
+		assert.Equal(t, "Bearer test-token", (*captured)["authorization"])
+		assert.Equal(t, "application/json", (*captured)["contentType"])
+
+		payload := sendMailPayload{}
+		assert.NoError(t, json.Unmarshal((*captured)["body"].([]byte), &payload))
+		assert.Equal(t, "Report Title", payload.Message.Subject)
+		assert.Equal(t, "HTML", payload.Message.Body.ContentType)
+		assert.Equal(t, "<h1>Summary</h1>", payload.Message.Body.Content)
+		assert.Len(t, payload.Message.ToRecipients, 1)
+		assert.Equal(t, "to@example.com", payload.Message.ToRecipients[0].EmailAddress.Address)
+		assert.Len(t, payload.Message.CcRecipients, 1)
+		assert.Nil(t, payload.Message.BccRecipients)
+		assert.False(t, payload.SaveToSentItems)
+	})
+
+	t.Run("uses text content type for non-html reports", func(t *testing.T) {
+		server, captured := newGraphServer(t, http.StatusAccepted, "")
+
+		client := email.NewGraphAPIClient("tenant", "client", "secret", "user", email.GraphAPIClientOptions{
+			AzureADEndpoint: server.URL,
+			GraphEndpoint:   server.URL,
+		})
+
+		err := client.Send(email.Report{Title: "Title", Message: "plain", Format: "text"}, []string{"to@example.com"})
+		assert.NoError(t, err)
+
+		payload := sendMailPayload{}
+		assert.NoError(t, json.Unmarshal((*captured)["body"].([]byte), &payload))
+		assert.Equal(t, "Text", payload.Message.Body.ContentType)
+		assert.True(t, payload.SaveToSentItems)
+	})
+
+	t.Run("returns error including response body on failure", func(t *testing.T) {
+		server, _ := newGraphServer(t, http.StatusForbidden, `{"error":{"message":"access denied"}}`)
+
+		client := email.NewGraphAPIClient("tenant", "client", "secret", "user", email.GraphAPIClientOptions{
+			AzureADEndpoint: server.URL,
+			GraphEndpoint:   server.URL,
+		})
+
+		err := client.Send(email.Report{Title: "Title", Message: "msg"}, []string{"to@example.com"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "access denied")
+	})
+}

--- a/pkg/kubernetes/secrets/client.go
+++ b/pkg/kubernetes/secrets/client.go
@@ -17,6 +17,7 @@ type Values struct {
 	Channel         string `json:"channel,omitempty"`
 	Username        string `json:"username,omitempty"`
 	Password        string `json:"password,omitempty"`
+	ClientSecret    string `json:"clientSecret,omitempty"`
 	APIKey          string `json:"apiKey,omitempty"`
 	AccessKeyID     string `json:"accessKeyId,omitempty"`
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
@@ -65,6 +66,10 @@ func (c *k8sClient) Get(ctx context.Context, name string) (Values, error) {
 
 	if password, ok := secret.Data["password"]; ok {
 		values.Password = string(password)
+	}
+
+	if clientSecret, ok := secret.Data["clientSecret"]; ok {
+		values.ClientSecret = string(clientSecret)
 	}
 
 	if apiKey, ok := secret.Data["apiKey"]; ok {


### PR DESCRIPTION
### Description

This pull request adds support for sending email reports using the **Microsoft Graph API**. It allows environments that disable SMTP or require OAuth2-based authentication to configure Microsoft 365 / Exchange Online mailboxes for email dispatch.

Key features and implementation details:

- **`email.Sender` interface**: extracted a new interface implemented by both the original SMTP client and the new Microsoft Graph API client. The existing SMTP `Client` struct and `NewClient` signature remain unchanged, ensuring full backward compatibility.
- **OAuth2 client credentials flow** (`golang.org/x/oauth2/clientcredentials`): the token is fetched on first use and refreshed automatically when it expires.
- **CC & BCC support** for all sent reports.
- **Sent Items control** (`disableSaveToSentItems`): set to `true` to prevent sent emails from appearing in the Sent Items folder; defaults to `false` (saving enabled, aligning with the Graph API default).
- **Secret support** (`secretRef`): the client secret can be read from an existing Kubernetes Secret (key `clientSecret`) via the existing `secrets.Client`, instead of being set inline. The report CronJobs get a `POD_NAMESPACE` env var so the secret is resolved in the release namespace.
- **Sovereign cloud support**: `azureADEndpoint` and `graphEndpoint` overrides (e.g. for Microsoft Cloud Germany / US Government).
- **Correct JSON marshalling**: empty CC/BCC recipient lists are omitted from the payload rather than sent as empty arrays, conforming to Microsoft Graph API specs.
- **Error diagnostics**: the full Graph API error response body is included in returned errors to ease troubleshooting.
- **Helm chart**: new `emailReports.graphAPI` parameters in `values.yaml` (documented in the chart README) and rendered via `email-reports.tmpl`.

### Related Issue

N/A

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Proof of Verification / Manifests

#### 1. Helm configuration example

```yaml
emailReports:
  graphAPI:
    enabled: true
    tenant: "your-tenant-id"
    clientID: "your-client-id"
    clientSecret: "your-client-secret"
    # or read the client secret from an existing Secret (key: clientSecret)
    # secretRef: "name-of-k8s-secret"
    userID: "sender-user-id"
    cc:
      - "cc-recipient@example.com"
    bcc:
      - "bcc-recipient@example.com"
    disableSaveToSentItems: false
```

#### 2. Unit tests

- `pkg/config/resolver_test.go` / `pkg/config/resolver_internal_test.go`: verify config parsing, that the Graph API client is resolved when enabled (and the SMTP client when disabled), and that the client secret is resolved from a referenced Kubernetes Secret (including fallback behaviour).
- `pkg/email/graphapi_test.go`: httptest-based tests asserting the full `sendMail` payload (subject, body content type, recipients, CC/BCC omission, `saveToSentItems`), the OAuth2 bearer token, and error reporting on non-202 responses.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/policy-reporter/blob/main/CONTRIBUTING.md).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the Helm chart `values.yaml` and chart README.
- [x] My code passes CI pipelines.
