### PR TITLE
feat(db): add error metric for write operations

### DIFF
--- a/pkg/database/bun.go
+++ b/pkg/database/bun.go
@@ -10,6 +10,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/openreports/reports-api/apis/openreports.io/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 	"github.com/uptrace/bun/dialect/sqlitedialect"
@@ -958,6 +959,7 @@ func (s *Store) Add(ctx context.Context, report openreports.ReportInterface) err
 	_, err := s.db.NewInsert().Model(MapPolicyReport(report)).Exec(ctx)
 	if err != nil {
 		zap.L().Error("failed to persist policy report", zap.Error(err))
+		errorMetric.With(prometheus.Labels{"operation": "INSERT", "table": "policy_report", "reason": mapReason(err)}).Inc()
 	}
 
 	filters := chunkSlice(MapPolicyReportFilter(report), 50)
@@ -965,6 +967,7 @@ func (s *Store) Add(ctx context.Context, report openreports.ReportInterface) err
 		_, err = s.db.NewInsert().Ignore().Model(&list).Exec(ctx)
 		if err != nil {
 			zap.L().Error("failed to bulk import policy report filter", zap.Error(err))
+			errorMetric.With(prometheus.Labels{"operation": "INSERT", "table": "policy_report_filter", "reason": mapReason(err)}).Inc()
 			return err
 		}
 	}
@@ -974,6 +977,7 @@ func (s *Store) Add(ctx context.Context, report openreports.ReportInterface) err
 		_, err = s.db.NewInsert().Model(&list).Exec(ctx)
 		if err != nil {
 			zap.L().Error("failed to bulk import policy report resources", zap.Error(err))
+			errorMetric.With(prometheus.Labels{"operation": "INSERT", "table": "policy_report_resource", "reason": mapReason(err)}).Inc()
 			return err
 		}
 	}
@@ -983,6 +987,7 @@ func (s *Store) Add(ctx context.Context, report openreports.ReportInterface) err
 		_, err = s.db.NewInsert().Ignore().Model(&list).Exec(ctx)
 		if err != nil {
 			zap.L().Error("failed to bulk import policy report results", zap.Error(err))
+			errorMetric.With(prometheus.Labels{"operation": "INSERT", "table": "policy_report_result", "reason": mapReason(err)}).Inc()
 			return err
 		}
 	}
@@ -1004,7 +1009,8 @@ func (s *Store) Update(ctx context.Context, report openreports.ReportInterface) 
 func (s *Store) Remove(ctx context.Context, id string) error {
 	_, err := s.db.NewDelete().Model((*PolicyReport)(nil)).Where("id = ?", id).Exec(ctx)
 	if err != nil {
-		zap.L().Error("failed to remove previews policy report", zap.Error(err))
+		zap.L().Error("failed to remove previous policy report", zap.Error(err))
+		errorMetric.With(prometheus.Labels{"operation": "DELETE", "table": "policy_report", "reason": mapReason(err)}).Inc()
 	}
 
 	return err
@@ -1014,6 +1020,7 @@ func (s *Store) CleanUp(ctx context.Context) error {
 	_, err := s.db.NewDelete().Model((*PolicyReport)(nil)).Where("id is not null").Exec(ctx)
 	if err != nil {
 		zap.L().Error("failed to remove policy reports", zap.Error(err))
+		errorMetric.With(prometheus.Labels{"operation": "DELETE", "table": "policy_report", "reason": mapReason(err)}).Inc()
 	}
 
 	return err

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,6 +10,11 @@ import (
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect"
 )
+
+var errorMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "policy_reporter_database_errors_total",
+	Help: "Total number of database errors",
+}, []string{"operation", "table", "reason"})
 
 func RegisterDBStats(name string) *prometheus.GaugeVec {
 	return promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -128,4 +134,20 @@ func dbSystem(db *bun.DB) string {
 	default:
 		return ""
 	}
+}
+
+func mapReason(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	if strings.Contains(err.Error(), "timeout") {
+		return "timeout"
+	}
+
+	if strings.Contains(err.Error(), "refused") {
+		return "connection_refused"
+	}
+
+	return "unknown"
 }


### PR DESCRIPTION
This pull request introduces improved error monitoring for database operations by adding Prometheus metrics to track and categorize database errors. The most important changes are grouped below:

**Metrics and Monitoring Enhancements:**

* Added a new Prometheus counter metric `policy_reporter_database_errors_total` to count database errors, labeled by operation, table, and reason.
* Introduced a helper function `mapReason` to categorize error reasons, such as "timeout" and "connection_refused", for more granular error reporting.

**Instrumentation of Database Operations:**

* Updated the `Add`, `Remove`, and `CleanUp` methods in `pkg/database/bun.go` to increment the error metric with appropriate labels whenever a database error occurs, covering inserts and deletes on various tables. [[1]](diffhunk://#diff-098257181390d9ac7bec0eab5682d7f53ffc66a469a830f4eeff94418023e397R962-R970) [[2]](diffhunk://#diff-098257181390d9ac7bec0eab5682d7f53ffc66a469a830f4eeff94418023e397R980) [[3]](diffhunk://#diff-098257181390d9ac7bec0eab5682d7f53ffc66a469a830f4eeff94418023e397R990) [[4]](diffhunk://#diff-098257181390d9ac7bec0eab5682d7f53ffc66a469a830f4eeff94418023e397L1007-R1013) [[5]](diffhunk://#diff-098257181390d9ac7bec0eab5682d7f53ffc66a469a830f4eeff94418023e397R1023)

**Dependency Updates:**

* Added missing imports for Prometheus client libraries to support the new metrics. [[1]](diffhunk://#diff-098257181390d9ac7bec0eab5682d7f53ffc66a469a830f4eeff94418023e397R13) [[2]](diffhunk://#diff-f0f4309ddd35eb369dc69b174f4f94ad851ee8c0b0a09ce7e48fd65f217ee2f7R5)

These changes will help proactively monitor and diagnose database issues by exposing detailed error metrics.