### PR TITLE
feat: add replicaset owner check

### DIFF
--- a/charts/policy-reporter/templates/clusterrole.yaml
+++ b/charts/policy-reporter/templates/clusterrole.yaml
@@ -59,4 +59,10 @@ rules:
   - jobs
   verbs:
   - get
+- apiGroups:
+  - 'apps'
+  resources:
+  - replicasets
+  verbs:
+  - get
 {{- end -}}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -241,7 +241,7 @@ sourceFilters:
     disableClusterReports: false
     # -- Filter out Reports based on the scope resource kind
     kinds:
-      exclude: [ReplicaSet]
+      exclude: []
 
 global:
   # -- additional labels added on each resource

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -188,6 +188,7 @@ type SourceFilter struct {
 	Selector              SourceSelector `mapstructure:"selector"`
 	Kinds                 ValueFilter    `mapstructure:"kinds"`
 	Sources               ValueFilter    `mapstructure:"sources"`
+	Resources             ValueFilter    `mapstructure:"resources"`
 	Namespaces            ValueFilter    `mapstructure:"namespaces"`
 	UncontrolledOnly      bool           `mapstructure:"uncontrolledOnly"`
 	DisableClusterReports bool           `mapstructure:"disableClusterReports"`

--- a/pkg/config/resolver.go
+++ b/pkg/config/resolver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/uptrace/bun/dialect"
 	mail "github.com/xhit/go-simple-mail/v2"
 	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
@@ -39,6 +40,7 @@ import (
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/namespaces"
 	orclient "github.com/kyverno/policy-reporter/pkg/kubernetes/openreports"
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/pods"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/replicasets"
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/secrets"
 	wgpolicyclient "github.com/kyverno/policy-reporter/pkg/kubernetes/wgpolicy"
 	"github.com/kyverno/policy-reporter/pkg/leaderelection"
@@ -249,16 +251,22 @@ func (r *Resolver) WGPolicyQueue() (*wgpolicyclient.WGPolicyQueue, error) {
 		return nil, err
 	}
 
+	replicasetsClient, err := r.ReplicaSetClient()
+	if err != nil {
+		return nil, err
+	}
+
 	return wgpolicyclient.NewWGPolicyQueue(
 		kubernetes.NewDebouncer(1*time.Minute, r.EventPublisher()),
 		workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{
 			Name: "wgreport-queue",
 		}),
 		polrClient,
-		report.NewSourceFilter(podsClient, jobsClient, helper.Map(r.config.SourceFilters, func(f SourceFilter) report.SourceValidation {
+		report.NewSourceFilter(podsClient, jobsClient, replicasetsClient, gocache.New[types.UID, bool](1*time.Minute, 10*time.Second), helper.Map(r.config.SourceFilters, func(f SourceFilter) report.SourceValidation {
 			return report.SourceValidation{
 				Selector:              report.ReportSelector(f.Selector),
 				Kinds:                 ToRuleSet(f.Kinds),
+				Resources:             ToRuleSet(f.Resources),
 				Sources:               ToRuleSet(f.Sources),
 				Namespaces:            ToRuleSet(f.Namespaces),
 				UncontrolledOnly:      f.UncontrolledOnly,
@@ -285,13 +293,18 @@ func (r *Resolver) ORQueue() (*orclient.ORQueue, error) {
 		return nil, err
 	}
 
+	replicasetsClient, err := r.ReplicaSetClient()
+	if err != nil {
+		return nil, err
+	}
+
 	return orclient.NewORQueue(
 		kubernetes.NewDebouncer(1*time.Minute, r.EventPublisher()),
 		workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{
 			Name: "orreport-queue",
 		}),
 		polrClient,
-		report.NewSourceFilter(podsClient, jobsClient, helper.Map(r.config.SourceFilters, func(f SourceFilter) report.SourceValidation {
+		report.NewSourceFilter(podsClient, jobsClient, replicasetsClient, gocache.New[types.UID, bool](1*time.Minute, 10*time.Second), helper.Map(r.config.SourceFilters, func(f SourceFilter) report.SourceValidation {
 			return report.SourceValidation{
 				Selector:              report.ReportSelector(f.Selector),
 				Kinds:                 ToRuleSet(f.Kinds),
@@ -425,6 +438,16 @@ func (r *Resolver) PodClient() (pods.Client, error) {
 	}
 
 	return pods.NewClient(clientset.CoreV1()), nil
+}
+
+// ReplicaSetClient resolver method
+func (r *Resolver) ReplicaSetClient() (replicasets.Client, error) {
+	clientset, err := r.Clientset()
+	if err != nil {
+		return nil, err
+	}
+
+	return replicasets.NewClient(clientset.AppsV1()), nil
 }
 
 // JobClient resolver method

--- a/pkg/kubernetes/jobs/client.go
+++ b/pkg/kubernetes/jobs/client.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/batch/v1"
 
-	"github.com/kyverno/policy-reporter/pkg/kubernetes"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/retry"
 )
 
 type Client interface {
@@ -20,7 +20,7 @@ type k8sClient struct {
 }
 
 func (c *k8sClient) Get(scope *corev1.ObjectReference) (*batchv1.Job, error) {
-	return kubernetes.Retry(func() (*batchv1.Job, error) {
+	return retry.Retry(func() (*batchv1.Job, error) {
 		return c.client.Jobs(scope.Namespace).Get(context.Background(), scope.Name, metav1.GetOptions{})
 	})
 }

--- a/pkg/kubernetes/namespaces/client.go
+++ b/pkg/kubernetes/namespaces/client.go
@@ -13,7 +13,7 @@ import (
 	gocache "zgo.at/zcache/v2"
 
 	"github.com/kyverno/policy-reporter/pkg/helper"
-	"github.com/kyverno/policy-reporter/pkg/kubernetes"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/retry"
 )
 
 type Client interface {
@@ -56,7 +56,7 @@ func (c *k8sClient) List(ctx context.Context, selector map[string]string) ([]str
 		return cached, nil
 	}
 
-	list, err := kubernetes.Retry(func() ([]string, error) {
+	list, err := retry.Retry(func() ([]string, error) {
 		namespaces, err := c.client.List(ctx, metav1.ListOptions{LabelSelector: s.String()})
 		if err != nil {
 			return nil, err

--- a/pkg/kubernetes/openreports/policy_report_client_test.go
+++ b/pkg/kubernetes/openreports/policy_report_client_test.go
@@ -42,7 +42,7 @@ func Test_PolicyReportWatcher(t *testing.T) {
 		kubernetes.NewDebouncer(0, publisher),
 		workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		restClient.OpenreportsV1alpha1(),
-		report.NewSourceFilter(nil, nil, []report.SourceValidation{}),
+		report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{}),
 		result.NewReconditioner(nil),
 	)
 
@@ -96,7 +96,7 @@ func Test_ClusterPolicyReportWatcher(t *testing.T) {
 		kubernetes.NewDebouncer(0, publisher),
 		workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		restClient.OpenreportsV1alpha1(),
-		report.NewSourceFilter(nil, nil, []report.SourceValidation{}),
+		report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{}),
 		result.NewReconditioner(nil),
 	)
 
@@ -139,7 +139,7 @@ func Test_HasSynced(t *testing.T) {
 		kubernetes.NewDebouncer(0, report.NewEventPublisher()),
 		workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
 		restClient.OpenreportsV1alpha1(),
-		report.NewSourceFilter(nil, nil, []report.SourceValidation{}),
+		report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{}),
 		result.NewReconditioner(nil),
 	)
 

--- a/pkg/kubernetes/pods/client.go
+++ b/pkg/kubernetes/pods/client.go
@@ -7,7 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/kyverno/policy-reporter/pkg/kubernetes"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/retry"
 )
 
 type Client interface {
@@ -19,7 +19,7 @@ type k8sClient struct {
 }
 
 func (c *k8sClient) Get(scope *corev1.ObjectReference) (*corev1.Pod, error) {
-	return kubernetes.Retry(func() (*corev1.Pod, error) {
+	return retry.Retry(func() (*corev1.Pod, error) {
 		return c.client.Pods(scope.Namespace).Get(context.Background(), scope.Name, metav1.GetOptions{})
 	})
 }

--- a/pkg/kubernetes/replicasets/client.go
+++ b/pkg/kubernetes/replicasets/client.go
@@ -1,0 +1,32 @@
+package replicasets
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/retry"
+)
+
+type Client interface {
+	Get(scope *corev1.ObjectReference) (*appsv1.ReplicaSet, error)
+}
+
+type k8sClient struct {
+	client v1.ReplicaSetsGetter
+}
+
+func (c *k8sClient) Get(scope *corev1.ObjectReference) (*appsv1.ReplicaSet, error) {
+	return retry.Retry(func() (*appsv1.ReplicaSet, error) {
+		return c.client.ReplicaSets(scope.Namespace).Get(context.Background(), scope.Name, metav1.GetOptions{})
+	})
+}
+
+func NewClient(client v1.ReplicaSetsGetter) Client {
+	return &k8sClient{
+		client: client,
+	}
+}

--- a/pkg/kubernetes/retry/retry.go
+++ b/pkg/kubernetes/retry/retry.go
@@ -1,4 +1,4 @@
-package kubernetes
+package retry
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/kubernetes/retry/retry_test.go
+++ b/pkg/kubernetes/retry/retry_test.go
@@ -1,4 +1,4 @@
-package kubernetes_test
+package retry_test
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/kyverno/policy-reporter/pkg/kubernetes"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/retry"
 )
 
 func newFakeClient() v1.NamespaceInterface {
@@ -63,7 +63,7 @@ func TestRetry(t *testing.T) {
 		t.Parallel()
 		client := &ns{NamespaceInterface: newFakeClient()}
 
-		list, err := kubernetes.Retry(func() (*corev1.NamespaceList, error) {
+		list, err := retry.Retry(func() (*corev1.NamespaceList, error) {
 			return client.List(context.Background(), metav1.ListOptions{})
 		})
 
@@ -75,7 +75,7 @@ func TestRetry(t *testing.T) {
 		t.Parallel()
 		client := &ns{maxRetry: 1, NamespaceInterface: newFakeClient()}
 
-		list, err := kubernetes.Retry(func() (*corev1.NamespaceList, error) {
+		list, err := retry.Retry(func() (*corev1.NamespaceList, error) {
 			return client.List(context.Background(), metav1.ListOptions{})
 		})
 
@@ -87,7 +87,7 @@ func TestRetry(t *testing.T) {
 		t.Parallel()
 		client := &ns{NamespaceInterface: newFakeClient(), err: true}
 
-		_, err := kubernetes.Retry(func() (*corev1.NamespaceList, error) {
+		_, err := retry.Retry(func() (*corev1.NamespaceList, error) {
 			return client.List(context.Background(), metav1.ListOptions{})
 		})
 
@@ -98,7 +98,7 @@ func TestRetry(t *testing.T) {
 		t.Parallel()
 		try := 0
 
-		_, err := kubernetes.Retry(func() (any, error) {
+		_, err := retry.Retry(func() (any, error) {
 			try++
 
 			return nil, &kerr.StatusError{
@@ -114,7 +114,7 @@ func TestRetry(t *testing.T) {
 		t.Parallel()
 		try := 0
 
-		_, err := kubernetes.Retry(func() (any, error) {
+		_, err := retry.Retry(func() (any, error) {
 			try++
 
 			return nil, &kerr.StatusError{
@@ -130,7 +130,7 @@ func TestRetry(t *testing.T) {
 		t.Parallel()
 		try := 0
 
-		_, err := kubernetes.Retry(func() (any, error) {
+		_, err := retry.Retry(func() (any, error) {
 			try++
 
 			return nil, &kerr.StatusError{
@@ -146,7 +146,7 @@ func TestRetry(t *testing.T) {
 		t.Parallel()
 		try := 0
 
-		_, err := kubernetes.Retry(func() (any, error) {
+		_, err := retry.Retry(func() (any, error) {
 			try++
 
 			return nil, &kerr.StatusError{

--- a/pkg/kubernetes/secrets/client.go
+++ b/pkg/kubernetes/secrets/client.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/kyverno/policy-reporter/pkg/kubernetes"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/retry"
 )
 
 type Values struct {
@@ -39,7 +39,7 @@ type k8sClient struct {
 }
 
 func (c *k8sClient) Get(ctx context.Context, name string) (Values, error) {
-	secret, err := kubernetes.Retry(func() (*corev1.Secret, error) {
+	secret, err := retry.Retry(func() (*corev1.Secret, error) {
 		return c.client.Get(ctx, name, metav1.GetOptions{})
 	})
 

--- a/pkg/report/source_filter.go
+++ b/pkg/report/source_filter.go
@@ -1,25 +1,23 @@
 package report
 
 import (
+	"fmt"
 	"strings"
 
 	"go.uber.org/zap"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gocache "zgo.at/zcache/v2"
 
+	"github.com/go-openapi/inflect"
 	"github.com/kyverno/policy-reporter/pkg/helper"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/jobs"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/pods"
+	"github.com/kyverno/policy-reporter/pkg/kubernetes/replicasets"
 	"github.com/kyverno/policy-reporter/pkg/openreports"
 	"github.com/kyverno/policy-reporter/pkg/validate"
 )
-
-type PodClient interface {
-	Get(res *corev1.ObjectReference) (*corev1.Pod, error)
-}
-
-type JobClient interface {
-	Get(res *corev1.ObjectReference) (*batchv1.Job, error)
-}
 
 type ReportSelector struct {
 	Source  string
@@ -29,6 +27,7 @@ type ReportSelector struct {
 type SourceValidation struct {
 	Selector              ReportSelector
 	Kinds                 validate.RuleSets
+	Resources             validate.RuleSets
 	Sources               validate.RuleSets
 	Namespaces            validate.RuleSets
 	UncontrolledOnly      bool
@@ -36,9 +35,11 @@ type SourceValidation struct {
 }
 
 type SourceFilter struct {
-	pods        PodClient
-	jobs        JobClient
+	pods        pods.Client
+	jobs        jobs.Client
+	replicasets replicasets.Client
 	validations []SourceValidation
+	controlled  *gocache.Cache[types.UID, bool]
 }
 
 func (s *SourceFilter) Validate(polr openreports.ReportInterface) bool {
@@ -80,10 +81,16 @@ func (s *SourceFilter) run(polr openreports.ReportInterface, options SourceValid
 		zap.String("kind", scope.Kind),
 		zap.String("name", scope.Name),
 		zap.String("namespace", scope.Namespace),
+		zap.String("uid", string(scope.UID)),
 	)
 
 	if options.Kinds.Enabled() && !validate.MatchRuleSet(scope.Kind, options.Kinds) {
 		logger.Debug("filter scope resource kind")
+		return false
+	}
+
+	if options.Resources.Enabled() && !validate.MatchRuleSet(ToAPIString(scope), options.Resources) {
+		logger.Debug("filter scope resource api")
 		return false
 	}
 
@@ -92,7 +99,16 @@ func (s *SourceFilter) run(polr openreports.ReportInterface, options SourceValid
 		return false
 	}
 
-	if options.UncontrolledOnly && s.pods != nil && scope.Kind == "Pod" {
+	if !options.UncontrolledOnly {
+		return true
+	}
+
+	if ok, controlled := s.controlled.Get(scope.UID); ok {
+		logger.Debug("resource found in cache", zap.Bool("filter", controlled))
+		return controlled
+	}
+
+	if s.pods != nil && scope.Kind == "Pod" {
 		pod, err := s.pods.Get(scope)
 		if err != nil {
 			logger.Error("failed to get pod", zap.Error(err), zap.String("name", scope.Name), zap.String("namespace", scope.Namespace))
@@ -100,14 +116,33 @@ func (s *SourceFilter) run(polr openreports.ReportInterface, options SourceValid
 		}
 
 		if ok := Uncontrolled(pod.OwnerReferences, podControllers); ok {
+			s.cache(pod.UID, true)
 			return true
 		}
 
 		logger.Debug("filter controlled pod resource")
+		s.cache(pod.UID, false)
 		return false
 	}
 
-	if options.UncontrolledOnly && s.jobs != nil && scope.Kind == "Job" {
+	if s.replicasets != nil && scope.Kind == "ReplicaSet" && scope.APIVersion == "apps/v1" {
+		rs, err := s.replicasets.Get(scope)
+		if err != nil {
+			logger.Error("failed to get replicaset", zap.Error(err))
+			return true
+		}
+
+		if ok := Uncontrolled(rs.OwnerReferences, rsControllers); ok {
+			s.cache(rs.UID, true)
+			return true
+		}
+
+		logger.Debug("filter controlled replicaset resource")
+		s.cache(rs.UID, false)
+		return false
+	}
+
+	if s.jobs != nil && scope.Kind == "Job" {
 		job, err := s.jobs.Get(scope)
 		if err != nil {
 			logger.Error("failed to get job", zap.Error(err))
@@ -115,25 +150,45 @@ func (s *SourceFilter) run(polr openreports.ReportInterface, options SourceValid
 		}
 
 		if ok := Uncontrolled(job.OwnerReferences, jobControllers); ok {
+			s.cache(job.UID, true)
 			return true
 		}
 
 		logger.Debug("filter controlled job resource")
+		s.cache(job.UID, false)
 		return false
 	}
 
 	return true
 }
 
-func NewSourceFilter(pods PodClient, jobs JobClient, validations []SourceValidation) *SourceFilter {
-	return &SourceFilter{pods: pods, jobs: jobs, validations: validations}
+func (s *SourceFilter) cache(uid types.UID, controlled bool) {
+	if uid == "" || s.controlled == nil {
+		return
+	}
+
+	s.controlled.Set(uid, controlled)
 }
 
-var podControllers = []string{"ReplicaSet", "DaemonSet", "Job", "StatefulSet"}
+func NewSourceFilter(pods pods.Client, jobs jobs.Client, rs replicasets.Client, cache *gocache.Cache[types.UID, bool], validations []SourceValidation) *SourceFilter {
+	return &SourceFilter{pods: pods, jobs: jobs, replicasets: rs, controlled: cache, validations: validations}
+}
 
-var jobControllers = []string{"CronJob"}
+var podControllers = map[string]bool{
+	"apps/v1/ReplicaSet":  true,
+	"apps/v1/StatefulSet": true,
+	"batch/v1/Job":        true,
+}
 
-func Uncontrolled(owner []metav1.OwnerReference, controllers []string) bool {
+var jobControllers = map[string]bool{
+	"batch/v1/CronJob": true,
+}
+
+var rsControllers = map[string]bool{
+	"apps/v1/Deployment": true,
+}
+
+func Uncontrolled(owner []metav1.OwnerReference, controllers map[string]bool) bool {
 	if len(owner) == 0 {
 		return true
 	}
@@ -144,7 +199,7 @@ func Uncontrolled(owner []metav1.OwnerReference, controllers []string) bool {
 			continue
 		}
 
-		if *isController && helper.Contains(o.Kind, controllers) {
+		if *isController && controllers[ToResourceString(o)] {
 			return false
 		}
 	}
@@ -158,4 +213,14 @@ func Match(polr openreports.ReportInterface, selector ReportSelector) bool {
 	}
 
 	return selector.Source == "" || strings.EqualFold(selector.Source, polr.GetSource())
+}
+
+func ToResourceString(o metav1.OwnerReference) string {
+	return fmt.Sprintf("%s/%s", o.APIVersion, o.Kind)
+}
+
+func ToAPIString(res *corev1.ObjectReference) string {
+	resource := inflect.Pluralize(strings.ToLower(res.Kind))
+
+	return fmt.Sprintf("%s.%s", resource, res.APIVersion)
 }

--- a/pkg/report/source_filter.go
+++ b/pkg/report/source_filter.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-openapi/inflect"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gocache "zgo.at/zcache/v2"
 
-	"github.com/go-openapi/inflect"
 	"github.com/kyverno/policy-reporter/pkg/helper"
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/jobs"
 	"github.com/kyverno/policy-reporter/pkg/kubernetes/pods"

--- a/pkg/report/source_filter_test.go
+++ b/pkg/report/source_filter_test.go
@@ -8,6 +8,8 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gocache "zgo.at/zcache/v2"
 
 	"github.com/kyverno/policy-reporter/pkg/fixtures"
 	"github.com/kyverno/policy-reporter/pkg/openreports"
@@ -42,7 +44,7 @@ func TestSourceFilter(t *testing.T) {
 	t.Parallel()
 	t.Run("include by namespace succeed", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Sources: []string{"kyverno"},
@@ -64,7 +66,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("include by namespace fails", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -86,7 +88,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("include by kind succeed", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -108,7 +110,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("include by kind fails", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -130,7 +132,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("disable cluster reports", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -152,7 +154,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("include by kind succeed", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -179,7 +181,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(&c, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(&c, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -211,7 +213,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(nil, &c, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, &c, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -243,7 +245,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(&c, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(&c, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -267,7 +269,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(nil, &c, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, &c, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -292,7 +294,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(&c, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(&c, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -317,7 +319,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(nil, &c, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, &c, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -341,7 +343,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(&c, nil, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(&c, nil, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -365,7 +367,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(nil, &c, nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, &c, nil, gocache.New[types.UID, bool](gocache.DefaultExpiration, 0), []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",

--- a/pkg/report/source_filter_test.go
+++ b/pkg/report/source_filter_test.go
@@ -42,7 +42,7 @@ func TestSourceFilter(t *testing.T) {
 	t.Parallel()
 	t.Run("include by namespace succeed", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Sources: []string{"kyverno"},
@@ -64,7 +64,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("include by namespace fails", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -86,7 +86,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("include by kind succeed", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -108,7 +108,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("include by kind fails", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -130,7 +130,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("disable cluster reports", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -152,7 +152,7 @@ func TestSourceFilter(t *testing.T) {
 
 	t.Run("include by kind succeed", func(t *testing.T) {
 		t.Parallel()
-		filter := report.NewSourceFilter(nil, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -179,7 +179,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(&c, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(&c, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -211,7 +211,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(nil, &c, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, &c, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -243,7 +243,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(&c, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(&c, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -267,7 +267,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(nil, &c, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, &c, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -292,7 +292,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(&c, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(&c, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -317,7 +317,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(nil, &c, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, &c, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -341,7 +341,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(&c, nil, []report.SourceValidation{
+		filter := report.NewSourceFilter(&c, nil, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",
@@ -365,7 +365,7 @@ func TestSourceFilter(t *testing.T) {
 			}}},
 		}
 
-		filter := report.NewSourceFilter(nil, &c, []report.SourceValidation{
+		filter := report.NewSourceFilter(nil, &c, nil, nil, []report.SourceValidation{
 			{
 				Selector: report.ReportSelector{
 					Source: "kyverno",


### PR DESCRIPTION
fixes: https://github.com/kyverno/policy-reporter/issues/1143

This PR adds following changes/improvements:

* ReplicaSets are now checked for ownerReferences like Jobs, on RS with an owner reference are filtered out
* Caching OwnerReference checks by UID for one minute to reduce API calls
* New `resources` filter, expects a full resource api string like `replicasets.app/v1`
* The default ReplicaSet kind exclude for kyverno results was removed (replaced by the general rs check)