### PR TITLE
Ignore unknown fields in the custom result ID generator

### DIFF
--- a/pkg/report/result/id_generator.go
+++ b/pkg/report/result/id_generator.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/segmentio/fasthash/fnv1a"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
@@ -160,7 +161,19 @@ func NewIDGenerator(config []string) IDGenerator {
 			continue
 		}
 
-		mappings = append(mappings, fieldMapper[field])
+		mapper, ok := fieldMapper[field]
+		if !ok {
+			// An unknown field would append a nil FieldMapperFunc and panic
+			// on the first result the generator sees.
+			zap.L().Warn("unknown custom id field, ignoring", zap.String("field", field))
+			continue
+		}
+
+		mappings = append(mappings, mapper)
+	}
+
+	if len(mappings) == 0 {
+		return &defaultIDGenerator{}
 	}
 
 	return &customIDGenerator{mappings}

--- a/pkg/report/result/id_generator_test.go
+++ b/pkg/report/result/id_generator_test.go
@@ -67,6 +67,30 @@ func TestCustomGenerator(t *testing.T) {
 		}
 	})
 
+	t.Run("Unknown Field Is Ignored", func(t *testing.T) {
+		t.Parallel()
+		// an unmapped field used to append a nil FieldMapperFunc, which
+		// panicked on the first result
+		generator := result.NewIDGenerator([]string{"resource", "namesapce"})
+
+		id := generator.Generate(&openreports.ReportAdapter{Report: &v1alpha1.Report{}}, openreports.ResultAdapter{ReportResult: v1alpha1.ReportResult{Subjects: []corev1.ObjectReference{{Name: "test", Kind: "Pod"}}}})
+
+		if id != "18007334074686647077" {
+			t.Errorf("expected result id to be '18007334074686647077', got :%s", id)
+		}
+	})
+
+	t.Run("Only Unknown Fields Falls Back To The Default Generator", func(t *testing.T) {
+		t.Parallel()
+		generator := result.NewIDGenerator([]string{"nope"})
+
+		id := generator.Generate(&openreports.ReportAdapter{Report: &v1alpha1.Report{}}, openreports.ResultAdapter{ReportResult: v1alpha1.ReportResult{Subjects: []corev1.ObjectReference{{Name: "test", Kind: "Pod"}}}})
+
+		if id == "" {
+			t.Error("expected a generated id, got an empty string")
+		}
+	})
+
 	t.Run("ID From Scope", func(t *testing.T) {
 		t.Parallel()
 		generator := result.NewIDGenerator([]string{"resource"})


### PR DESCRIPTION
`NewIDGenerator` builds its mapper list like this:

```go
mappings = append(mappings, fieldMapper[field])
```

A Go map returns the zero value for a missing key, so a field name that is not one of the known mappers appends a nil `FieldMapperFunc`. Nothing catches it at config time, and `customIDGenerator.Generate` then calls it on the first result:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

A typo in the `customIDs` config, `namesapce` for `namespace` say, is enough to bring the reporter down as soon as a result arrives, and the config looks valid until then.

This switches to the comma-ok form, logs a warning naming the field, and skips it. If none of the configured fields are usable it returns the default generator rather than a generator with no mappings, which would hash nothing and give every result the same id.

Two cases added to `TestCustomGenerator`: one mixing a good field with a typo, which now produces the same id as the good field alone, and one where every field is unknown. Both panic on main and pass with the change. `go test ./pkg/report/...` is green.