### PR TITLE
feat(chart): allow custom config for /tmp volume on ui deployment

### DIFF
--- a/charts/policy-reporter/README.md
+++ b/charts/policy-reporter/README.md
@@ -460,6 +460,7 @@ Open `http://localhost:8082/` in your browser.
 | ui.revisionHistoryLimit | int | `10` | The number of revisions to keep |
 | ui.podSecurityContext | object | `{"runAsGroup":1234,"runAsUser":1234}` | Security context for the pod |
 | ui.envVars | list | `[]` | Allow additional env variables to be added |
+| ui.tmpVolume | object | `{}` | Allow custom configuration of the /tmp volume |
 | ui.rbac.enabled | bool | `true` | Create RBAC resources |
 | ui.securityContext.runAsUser | int | `1234` |  |
 | ui.securityContext.runAsNonRoot | bool | `true` |  |

--- a/charts/policy-reporter/templates/ui/deployment.yaml
+++ b/charts/policy-reporter/templates/ui/deployment.yaml
@@ -99,7 +99,11 @@ spec:
           secretName: {{ include "ui.fullname" . }}-config
           optional: true
       - name: tmp
+        {{- if .Values.ui.tmpVolume }}
+          {{- toYaml .Values.ui.tmpVolume | nindent 8 }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       {{- with .Values.ui.extraVolumes.volumes }}
       {{ toYaml . | nindent 6 | trim }}
       {{- end }}

--- a/charts/policy-reporter/values.yaml
+++ b/charts/policy-reporter/values.yaml
@@ -1249,6 +1249,9 @@ ui:
   # -- Allow additional env variables to be added
   envVars: []
 
+  # -- Allow custom configuration of the /tmp volume
+  tmpVolume: {}
+
   rbac:
     # -- Create RBAC resources
     enabled: true


### PR DESCRIPTION
re-used the implementation from the main deployment, which already allowed custom config for /tmp volume.