### PR TITLE
fix: move result filter to client and set pass and skip filter as default

### DIFF
--- a/pkg/listener/new_result.go
+++ b/pkg/listener/new_result.go
@@ -48,14 +48,6 @@ func (l *ResultListener) UnregisterSyncListener() {
 	l.syncListener = make([]report.SyncResultsListener, 0)
 }
 
-func (l *ResultListener) Validate(r openreports.ResultAdapter) bool {
-	if r.Result == openreports.StatusSkip || r.Result == openreports.StatusPass {
-		return false
-	}
-
-	return true
-}
-
 func (l *ResultListener) Listen(_ context.Context, event report.LifecycleEvent) {
 	logger := zap.L().Sugar()
 	logger.Debugf("new event: type %s, report ID %s", event.Type, event.PolicyReport.GetID())
@@ -109,8 +101,8 @@ func (l *ResultListener) Listen(_ context.Context, event report.LifecycleEvent) 
 	newResults := make([]openreports.ResultAdapter, 0)
 
 	for _, r := range event.PolicyReport.GetResults() {
-		if helper.Contains(r.GetID(), existing) || !l.Validate(r) {
-			logger.Debugf("result for %s, policy %s, rule %s: skipping result sending because the result is already in the cached results for this report or is a pass result", r.ResourceString(), r.Policy, r.Rule)
+		if helper.Contains(r.GetID(), existing) {
+			logger.Debugf("result for %s, policy %s, rule %s: skipping result sending because the result is already in the cached results for this report", r.ResourceString(), r.Policy, r.Rule)
 			continue
 		}
 

--- a/pkg/listener/new_result_test.go
+++ b/pkg/listener/new_result_test.go
@@ -197,15 +197,4 @@ func Test_ResultListener(t *testing.T) {
 
 		assert.Nil(t, called, "Expected Listener was unregistered")
 	})
-
-	t.Run("Check Validation Logic", func(t *testing.T) {
-		t.Parallel()
-		slistener := listener.NewResultListener(true, cache.NewInMemoryCache(time.Minute, time.Minute), time.Now())
-
-		assert.True(t, slistener.Validate(fixtures.FailPodResult))
-		assert.True(t, slistener.Validate(fixtures.WarnPodResult))
-		assert.True(t, slistener.Validate(fixtures.ErrorPodResult))
-		assert.False(t, slistener.Validate(fixtures.PassPodResult))
-		assert.False(t, slistener.Validate(fixtures.SkipPodResult))
-	})
 }

--- a/pkg/target/factory/factory.go
+++ b/pkg/target/factory/factory.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"go.uber.org/zap"
 
+	"github.com/kyverno/policy-reporter/pkg/crd/api/policyreport/v1alpha2"
 	"github.com/kyverno/policy-reporter/pkg/crd/api/targetconfig"
 	"github.com/kyverno/policy-reporter/pkg/crd/api/targetconfig/v1alpha1"
 	"github.com/kyverno/policy-reporter/pkg/filters"
@@ -971,7 +972,7 @@ func (f *TargetFactory) createResultFilter(filter filters.Filter, minimumSeverit
 			Selector: filter.Namespaces.Selector,
 		},
 		ToRuleSet(filter.Severities),
-		ToRuleSet(filter.Status),
+		ToRuleSet(DefaultStatusFilter(filter.Status)),
 		ToRuleSet(filter.Policies),
 		ToRuleSet(sourceFilter),
 		minimumSeverity,
@@ -1218,6 +1219,16 @@ func ToRuleSet(filter filters.ValueFilter) validate.RuleSets {
 		Include: filter.Include,
 		Exclude: filter.Exclude,
 	}
+}
+
+func DefaultStatusFilter(filter filters.ValueFilter) filters.ValueFilter {
+	if len(filter.Include) == 0 && len(filter.Exclude) == 0 {
+		return filters.ValueFilter{
+			Exclude: []string{v1alpha2.StatusPass, v1alpha2.StatusSkip},
+		}
+	}
+
+	return filter
 }
 
 func createConfig[T any](tc *v1alpha1.TargetConfig, config *T) *targetconfig.Config[T] {


### PR DESCRIPTION
This PR removes the global pass and skip result filter and moves the validation on the client/target level.

If no target status filter is configured it excludes pass and skip results as default.